### PR TITLE
Assume that ready is true if the ready field is not present

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -28,7 +28,7 @@ func (api *API) waitUntilReady(id string) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		if data["ready"] == true {
+		if data["ready"] == true || data["ready"] == nil {
 			data["id"] = id
 			return data, nil
 		}


### PR DESCRIPTION
This is a preliminary pull request, I still need to test it live.

The shared plans of `cloudamqp` do not include the `ready` field at all, so `Create` never returns for lemur or tiger plans.