### PR TITLE
Check status code

### DIFF
--- a/api/instance.go
+++ b/api/instance.go
@@ -49,7 +49,7 @@ func (api *API) ReadInstance(id string) (map[string]interface{}, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Got statuscode %d from api ", resp.StatusCode)
+		return nil, fmt.Errorf("Got statuscode %d from api: %s ", resp.StatusCode, resp.Status)
 	}
 	return data, nil
 }


### PR DESCRIPTION
Started to use terraform-provider which crashed all the time. After debugging I found out that the reponse status of the api request was never checked so the code continued running with unset variables.

This is to make cloudkarafka work with their terraform-provider which crashes when status isn't a 200 because of this line since data is nil. 

string_id := strconv.Itoa(int(data["id"].(float64)))

Maybe a better solution is that any 2xx response is ok.
