### PR TITLE
Add HTTPS to default firewall settings

### DIFF
--- a/api/security_firewall.go
+++ b/api/security_firewall.go
@@ -106,7 +106,7 @@ func (api *API) DeleteFirewallSettings(instanceID int) ([]map[string]interface{}
 
 func DefaultFirewallSettings() map[string]interface{} {
 	defaultRule := map[string]interface{}{
-		"services":    []string{"AMQP", "AMQPS", "STOMP", "STOMPS", "MQTT", "MQTTS"},
+		"services":    []string{"AMQP", "AMQPS", "STOMP", "STOMPS", "MQTT", "MQTTS", "HTTPS"},
 		"ports":       []int{},
 		"ip":          "0.0.0.0/0",
 		"description": "Default",


### PR DESCRIPTION
Users are now able to control if the HTTPS port should be open or not.

The default is that it is open.