### PR TITLE
Retry the request if backend is busy and timeouts

### DIFF
--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -34,7 +34,7 @@ func (api *API) ReadVpcInfo(instanceID int) (map[string]interface{}, error) {
 	return api.readVpcInfo(instanceID, 5, 20)
 }
 
-func (api *API) readVpcInfo(instanceID, attempts, sleep int) (map[string]interface{}, error) {
+func (api *API) readVpcInfoWithRetry(instanceID, attempts, sleep int) (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
 	log.Printf("[DEBUG] go-api::vpc_peering::info instance id: %v", instanceID)

--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -29,6 +30,11 @@ func (api *API) waitForPeeringStatus(instanceID int, peeringID string) (map[stri
 }
 
 func (api *API) ReadVpcInfo(instanceID int) (map[string]interface{}, error) {
+	// Initiale values, 5 attempts and 20 second sleep
+	return api.readVpcInfo(instanceID, 5, 20)
+}
+
+func (api *API) readVpcInfo(instanceID, attempts, sleep int) (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
 	log.Printf("[DEBUG] go-api::vpc_peering::info instance id: %v", instanceID)
@@ -39,10 +45,22 @@ func (api *API) ReadVpcInfo(instanceID int) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
+	statusCode := response.StatusCode
+	log.Printf("[DEBUG] go-api::vpc_peering::info statusCode: %d", statusCode)
+	switch {
+	case statusCode == 400:
+		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
+			if attempts--; attempts > 0 {
+				log.Printf("[INFO] go-api::vpc_peering::info Timeout talking to backend "+
+					"attempts left %d and retry in %d seconds", attempts, sleep)
+				time.Sleep(time.Duration(sleep) * time.Second)
+				return api.readVpcInfo(instanceID, attempts, 2*sleep)
+			} else {
+				return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
+			}
+		}
+	}
 	return data, nil
 }
 


### PR DESCRIPTION
## Description of the change

Retry the request if backend timeouts. Number of retries can be set in attempts, and the time interval between. The time interval will double for each new attempt.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

Create an instance with VPC and use data_source_vpc_info resource in terraform-provider-cloudamqp. To trigger timeout talking to backend, should be enough to stop machines. 

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 

### Deployment

- [ ] The environment (`heroku config`) has been updated with any new required `ENV` variables
