### PR TITLE
Add VPC peering and info for Google Cloud Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.3 (Dec 16, 2021)
+
+* api/vpc_gcp_peering.go - Added VPC peering and info for Google Cloud Platform.
+
 ## 1.5.2 (Nov 17, 2021)
 
 * api/security_firewall.go - Include `STREAM`, `STREAM_SSL` services in default rules. [#9](https://github.com/84codes/go-api/pull/16)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ## go-api provider version
-version = 1.5.2
+version = 1.5.3
 
 clean:
 	## remove previous installed go-api

--- a/api/vpc_gcp_peering.go
+++ b/api/vpc_gcp_peering.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+)
+
+func (api *API) waitForGcpPeeringStatus(instanceID int, peerID string) error {
+	for {
+		data, err := api.ReadVpcGcpPeering(instanceID, peerID)
+		if err != nil {
+			return err
+		}
+		rows := data["rows"].([]interface{})
+		if len(rows) > 0 {
+			for _, row := range rows {
+				tempRow := row.(map[string]interface{})
+				if tempRow["name"] != peerID {
+					continue
+				}
+				if tempRow["state"] == "ACTIVE" {
+					return nil
+				}
+			}
+			time.Sleep(10 * time.Second)
+		}
+	}
+}
+
+func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	failed := make(map[string]interface{})
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::request params: %v", params)
+	path := fmt.Sprintf("api/instances/%v/vpc-peering", instanceID)
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
+
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("Request VPC peering failed, status: %v, message: %s", response.StatusCode, failed)
+	}
+
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::request waiting for active state")
+	api.waitForGcpPeeringStatus(instanceID, data["peering"].(string))
+	return data, nil
+}
+
+func (api *API) ReadVpcGcpPeering(instanceID int, peerID string) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	failed := make(map[string]interface{})
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::read instance_id: %v, peer_id: %v", instanceID, peerID)
+	path := fmt.Sprintf("/api/instances/%v/vpc-peering", instanceID)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::read data: %v", data)
+
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("ReadRequest failed, status: %v, message: %s", response.StatusCode, failed)
+	}
+
+	return data, nil
+}
+
+func (api *API) UpdateVpcGcpPeering(instanceID int, peerID string) (map[string]interface{}, error) {
+	return api.ReadVpcGcpPeering(instanceID, peerID)
+}
+
+func (api *API) RemoveVpcGcpPeering(instanceID int, peerID string) error {
+	failed := make(map[string]interface{})
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::remove instance id: %v, peering id: %v", instanceID, peerID)
+	path := fmt.Sprintf("/api/instances/%v/vpc-peering/%v", instanceID, peerID)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != 204 {
+		return fmt.Errorf("RemoveVpcPeering failed, status: %v, message: %s", response.StatusCode, failed)
+	}
+	return nil
+}
+
+func (api *API) ReadVpcGcpInfo(instanceID int) (map[string]interface{}, error) {
+	// Initiale values, 5 attempts and 20 second sleep
+	return api.readVpcGcpInfoWithRetry(instanceID, 5, 20)
+}
+
+func (api *API) readVpcGcpInfoWithRetry(instanceID, attempts, sleep int) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	failed := make(map[string]interface{})
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::info instance id: %v", instanceID)
+	path := fmt.Sprintf("/api/instances/%v/vpc-peering/info", instanceID)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::info data: %v", data)
+
+	if err != nil {
+		return nil, err
+	}
+
+	statusCode := response.StatusCode
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::info statusCode: %d", statusCode)
+	switch {
+	case statusCode == 400:
+		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
+			if attempts--; attempts > 0 {
+				log.Printf("[INFO] go-api::vpc_gcp_peering::info Timeout talking to backend "+
+					"attempts left %d and retry in %d seconds", attempts, sleep)
+				time.Sleep(time.Duration(sleep) * time.Second)
+				return api.readVpcGcpInfoWithRetry(instanceID, attempts, 2*sleep)
+			} else {
+				return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
+			}
+		}
+	}
+	return data, nil
+}


### PR DESCRIPTION
Add api/vpc_gcp_peering.go to enable VPC peering and info for Google Cloud Platform.

### Friendly reminders
- [ ] Describe the problem / feature (ideally with [meaningful commit messages](https://tekin.co.uk/2019/02/a-talk-about-revision-histories))
- [ ] Lint rules pass
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] The environment (`heroku config`) has been updated if needed (new `ENV` variables)

### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
