### PR TITLE
Add support for retries and timeout to accept VPC peering

### DIFF
--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -102,6 +102,7 @@ func (api *API) retryAcceptVpcPeering(instanceID int, peeringID string, attempt,
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.retryAcceptVpcPeering(instanceID, peeringID, attempt, sleep, timeout)
 		}
+		return nil, fmt.Errorf("AcceptVpcPeering failed, status: %v, message: %s", response.StatusCode, failed)
 	} else if response.StatusCode != 200 {
 		return nil, fmt.Errorf("AcceptVpcPeering failed, status: %v, message: %s", response.StatusCode, failed)
 	}

--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -57,9 +57,8 @@ func (api *API) readVpcInfoWithRetry(instanceID, attempts, sleep int) (map[strin
 					"attempts left %d and retry in %d seconds", attempts, sleep)
 				time.Sleep(time.Duration(sleep) * time.Second)
 				return api.readVpcInfoWithRetry(instanceID, attempts, 2*sleep)
-			} else {
-				return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
 			}
+			return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
 		}
 	}
 	return data, nil
@@ -114,8 +113,7 @@ func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeou
 	if err != nil {
 		return nil, err
 	}
-	data, err := api.retryAcceptVpcPeering(instanceID, peeringID, 1, sleep, timeout)
-	return data, err
+	return api.retryAcceptVpcPeering(instanceID, peeringID, 1, sleep, timeout)
 }
 
 func (api *API) RemoveVpcPeering(instanceID int, peeringID string) error {

--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -15,6 +15,7 @@ func (api *API) waitForPeeringStatus(instanceID int, peeringID string) (map[stri
 		time.Sleep(10 * time.Second)
 		path := fmt.Sprintf("/api/instances/%v/vpc-peering/status/%v", instanceID, peeringID)
 		response, err := api.sling.New().Path(path).Receive(&data, &failed)
+		log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatus  response: %v, data: %v, failed: %v", response, data, failed)
 
 		if err != nil {
 			return nil, err
@@ -82,24 +83,39 @@ func (api *API) ReadVpcPeeringRequest(instanceID int, peeringID string) (map[str
 	return data, nil
 }
 
-func (api *API) AcceptVpcPeering(instanceID int, peeringID string) (map[string]interface{}, error) {
-	_, err := api.waitForPeeringStatus(instanceID, peeringID)
-
+func (api *API) retryAcceptVpcPeering(instanceID int, peeringID string, attempt, sleep, timeout int) (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering::accept instance id: %v, peering id: %v", instanceID, peeringID)
 	path := fmt.Sprintf("/api/instances/%v/vpc-peering/request/%v", instanceID, peeringID)
 	response, err := api.sling.New().Put(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc_peering::accept data: %v", data)
 
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
+	if attempt*sleep >= timeout {
+		return nil, fmt.Errorf("AcceptVpcPeering failed, reach timeout")
+	} else if response.StatusCode == 400 {
+		errorCode := failed["error_code"].(float64)
+		if errorCode == 40001 {
+			log.Printf("[DEBUG] go-api::vpc_peering::accept firewall not finished configuring will retry "+
+				"accept VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
+			attempt++
+			time.Sleep(time.Duration(sleep) * time.Second)
+			return api.retryAcceptVpcPeering(instanceID, peeringID, attempt, sleep, timeout)
+		}
+	} else if response.StatusCode != 200 {
 		return nil, fmt.Errorf("AcceptVpcPeering failed, status: %v, message: %s", response.StatusCode, failed)
 	}
-
 	return data, nil
+}
+
+func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
+	_, err := api.waitForPeeringStatus(instanceID, peeringID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := api.retryAcceptVpcPeering(instanceID, peeringID, 1, sleep, timeout)
+	return data, err
 }
 
 func (api *API) RemoveVpcPeering(instanceID int, peeringID string) error {

--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -93,7 +93,7 @@ func (api *API) retryAcceptVpcPeering(instanceID int, peeringID string, attempt,
 		return nil, err
 	}
 	if attempt*sleep >= timeout {
-		return nil, fmt.Errorf("AcceptVpcPeering failed, reach timeout")
+		return nil, fmt.Errorf("AcceptVpcPeering failed, reached timeout of %d seconds", timeout)
 	} else if response.StatusCode == 400 {
 		errorCode := failed["error_code"].(float64)
 		if errorCode == 40001 {

--- a/api/vpc_peering_withvpcid.go
+++ b/api/vpc_peering_withvpcid.go
@@ -59,9 +59,8 @@ func (api *API) readVpcInfoWithRetryWithVpcId(vpcID string, attempts, sleep int)
 					"attempts left %d and retry in %d seconds", attempts, sleep)
 				time.Sleep(time.Duration(sleep) * time.Second)
 				return api.readVpcInfoWithRetryWithVpcId(vpcID, attempts, 2*sleep)
-			} else {
-				return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
 			}
+			return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
 		}
 	}
 	return data, nil
@@ -85,24 +84,39 @@ func (api *API) ReadVpcPeeringRequestWithVpcId(vpcID, peeringID string) (map[str
 	return data, nil
 }
 
-func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string) (map[string]interface{}, error) {
-	_, err := api.waitForPeeringStatusWithVpcId(vpcID, peeringID)
-
+func (api *API) retryAcceptVpcPeeringWithVpcId(vpcID, peeringID string, attempt, sleep, timeout int) (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::accept vpc id: %s, peering id: %s", vpcID, peeringID)
 	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/request/%s", vpcID, peeringID)
 	response, err := api.sling.New().Put(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::accept data: %v", data)
 
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("AcceptVpcPeering failed, status: %v, message: %s", response.StatusCode, failed)
+	if attempt*sleep >= timeout {
+		return nil, fmt.Errorf("AcceptVpcPeeringWithVpcId failed, reached timeout of %d seconds", timeout)
+	} else if response.StatusCode == 400 {
+		errorCode := failed["error_code"].(float64)
+		if errorCode == 40001 {
+			log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::accept firewall not finished configuring will retry "+
+				"accept VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
+			attempt++
+			time.Sleep(time.Duration(sleep) * time.Second)
+			return api.retryAcceptVpcPeeringWithVpcId(vpcID, peeringID, attempt, sleep, timeout)
+		}
+		return nil, fmt.Errorf("AcceptVpcPeeringWithVpcId failed, status: %v, message: %s", response.StatusCode, failed)
+	} else if response.StatusCode != 200 {
+		return nil, fmt.Errorf("AcceptVpcPeeringWithVpcId failed, status: %v, message: %s", response.StatusCode, failed)
 	}
-
 	return data, nil
+}
+
+func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
+	_, err := api.waitForPeeringStatusWithVpcId(vpcID, peeringID)
+	if err != nil {
+		return nil, err
+	}
+	return api.retryAcceptVpcPeeringWithVpcId(vpcID, peeringID, 1, sleep, timeout)
 }
 
 func (api *API) RemoveVpcPeeringWithVpcId(vpcID, peeringID string) error {


### PR DESCRIPTION
Failing doing multiple accept VPC peering request, due to firewall still being configured. 

- Adds retries upon bad request response with error code 40001
- Adds timeout after n seconds of retries
- Adds configurable sleep between retries and timeout 

Related to https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/152

### Friendly reminders
- [ ] Describe the problem / feature (ideally with [meaningful commit messages](https://tekin.co.uk/2019/02/a-talk-about-revision-histories))
- [ ] Lint rules pass
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] The environment (`heroku config`) has been updated if needed (new `ENV` variables)

### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
