### PR TITLE
Update endpoints to use async calls for plugin actions

### DIFF
--- a/api/plugins.go
+++ b/api/plugins.go
@@ -143,5 +143,6 @@ func (api *API) DeletePlugin(instanceID int, pluginName string) error {
 		return fmt.Errorf("DeletePlugin failed, status: %v, message: %s", response.StatusCode, failed)
 	}
 
-	return nil
+	_, err = api.waitUntilPluginChanged(instanceID, pluginName, false)
+	return err
 }

--- a/api/plugins.go
+++ b/api/plugins.go
@@ -10,7 +10,6 @@ import (
 type PluginParams struct {
 	Name    string `json:"plugin_name,omitempty"`
 	Enabled bool   `json:"enabled,omitempty"`
-	Async   bool   `json:"async,omitempty"`
 }
 
 func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enabled bool) (map[string]interface{}, error) {
@@ -30,7 +29,7 @@ func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enable
 
 func (api *API) EnablePlugin(instanceID int, pluginName string) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
-	params := &PluginParams{Name: pluginName, Async: true}
+	params := &PluginParams{Name: pluginName}
 	log.Printf("[DEBUG] go-api::plugin::enable instance id: %v, params: %v", instanceID, pluginName)
 	path := fmt.Sprintf("/api/instances/%d/plugins?async=true", instanceID)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
@@ -98,7 +97,7 @@ func (api *API) readPluginsWithRetry(instanceID, attempts, sleep int) ([]map[str
 
 func (api *API) UpdatePlugin(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
-	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool), Async: true}
+	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool)}
 	log.Printf("[DEBUG] go-api::plugin::update instance ID: %v, params: %v", instanceID, pluginParams)
 	path := fmt.Sprintf("/api/instances/%d/plugins?async=true", instanceID)
 	response, err := api.sling.New().Put(path).BodyJSON(pluginParams).Receive(nil, &failed)
@@ -131,10 +130,9 @@ func (api *API) DisablePlugin(instanceID int, pluginName string) (map[string]int
 
 func (api *API) DeletePlugin(instanceID int, pluginName string) error {
 	failed := make(map[string]interface{})
-	pluginParams := &PluginParams{Async: true}
 	log.Printf("[DEBUG] go-api::plugin::delete instance: %v, name: %v", instanceID, pluginName)
 	path := fmt.Sprintf("/api/instances/%d/plugins/%s?async=true", instanceID, pluginName)
-	response, err := api.sling.New().Delete(path).BodyJSON(pluginParams).Receive(nil, &failed)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 
 	if err != nil {
 		return err

--- a/api/plugins.go
+++ b/api/plugins.go
@@ -14,8 +14,8 @@ type PluginParams struct {
 
 func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enabled bool) (map[string]interface{}, error) {
 	log.Printf("[DEBUG] go-api::plugin::waitUntilPluginChanged instance id: %v, name: %v", instanceID, pluginName)
-	time.Sleep(10 * time.Second)
 	for {
+		time.Sleep(10 * time.Second)
 		response, err := api.ReadPlugin(instanceID, pluginName)
 		log.Printf("[DEBUG] go-api::plugin::waitUntilPluginChanged response: %v", response)
 		if err != nil {
@@ -24,8 +24,6 @@ func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enable
 		if response["enabled"] == enabled {
 			return response, nil
 		}
-
-		time.Sleep(10 * time.Second)
 	}
 }
 
@@ -33,7 +31,7 @@ func (api *API) EnablePlugin(instanceID int, pluginName string) (map[string]inte
 	failed := make(map[string]interface{})
 	params := &PluginParams{Name: pluginName}
 	log.Printf("[DEBUG] go-api::plugin::enable instance id: %v, params: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/plugins/async", instanceID)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
 
 	if err != nil {
@@ -102,7 +100,7 @@ func (api *API) UpdatePlugin(instanceID int, params map[string]interface{}) (map
 	failed := make(map[string]interface{})
 	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool)}
 	log.Printf("[DEBUG] go-api::plugin::update instance ID: %v, params: %v", instanceID, pluginParams)
-	path := fmt.Sprintf("/api/instances/%d/plugins", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/plugins/async", instanceID)
 	response, err := api.sling.New().Put(path).BodyJSON(pluginParams).Receive(nil, &failed)
 
 	if err != nil {
@@ -118,7 +116,7 @@ func (api *API) UpdatePlugin(instanceID int, params map[string]interface{}) (map
 func (api *API) DisablePlugin(instanceID int, pluginName string) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
 	log.Printf("[DEBUG] go-api::plugin::disable instance id: %v, name: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins/%s", instanceID, pluginName)
+	path := fmt.Sprintf("/api/instances/%d/plugins/async/%s", instanceID, pluginName)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 
 	if err != nil {
@@ -134,7 +132,7 @@ func (api *API) DisablePlugin(instanceID int, pluginName string) (map[string]int
 func (api *API) DeletePlugin(instanceID int, pluginName string) error {
 	failed := make(map[string]interface{})
 	log.Print("[DEBUG] go-api::plugin::delete instance: %v, name: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins/%s", instanceID, pluginName)
+	path := fmt.Sprintf("/api/instances/%d/plugins/async/%s", instanceID, pluginName)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 
 	if err != nil {

--- a/api/plugins.go
+++ b/api/plugins.go
@@ -32,7 +32,7 @@ func (api *API) EnablePlugin(instanceID int, pluginName string) (map[string]inte
 	failed := make(map[string]interface{})
 	params := &PluginParams{Name: pluginName, Async: true}
 	log.Printf("[DEBUG] go-api::plugin::enable instance id: %v, params: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/plugins?async=true", instanceID)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
 
 	if err != nil {
@@ -100,7 +100,7 @@ func (api *API) UpdatePlugin(instanceID int, params map[string]interface{}) (map
 	failed := make(map[string]interface{})
 	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool), Async: true}
 	log.Printf("[DEBUG] go-api::plugin::update instance ID: %v, params: %v", instanceID, pluginParams)
-	path := fmt.Sprintf("/api/instances/%d/plugins", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/plugins?async=true", instanceID)
 	response, err := api.sling.New().Put(path).BodyJSON(pluginParams).Receive(nil, &failed)
 
 	if err != nil {
@@ -116,7 +116,7 @@ func (api *API) UpdatePlugin(instanceID int, params map[string]interface{}) (map
 func (api *API) DisablePlugin(instanceID int, pluginName string) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
 	log.Printf("[DEBUG] go-api::plugin::disable instance id: %v, name: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins/%s", instanceID, pluginName)
+	path := fmt.Sprintf("/api/instances/%d/plugins/%s?async=true", instanceID, pluginName)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 
 	if err != nil {
@@ -132,8 +132,8 @@ func (api *API) DisablePlugin(instanceID int, pluginName string) (map[string]int
 func (api *API) DeletePlugin(instanceID int, pluginName string) error {
 	failed := make(map[string]interface{})
 	pluginParams := &PluginParams{Async: true}
-	log.Print("[DEBUG] go-api::plugin::delete instance: %v, name: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins/%s", instanceID, pluginName)
+	log.Printf("[DEBUG] go-api::plugin::delete instance: %v, name: %v", instanceID, pluginName)
+	path := fmt.Sprintf("/api/instances/%d/plugins/%s?async=true", instanceID, pluginName)
 	response, err := api.sling.New().Delete(path).BodyJSON(pluginParams).Receive(nil, &failed)
 
 	if err != nil {

--- a/api/plugins_community.go
+++ b/api/plugins_community.go
@@ -26,7 +26,7 @@ func (api *API) waitUntilPluginUninstalled(instanceID int, pluginName string) (m
 
 func (api *API) EnablePluginCommunity(instanceID int, pluginName string) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
-	params := &PluginParams{Name: pluginName, Async: true}
+	params := &PluginParams{Name: pluginName}
 	log.Printf("[DEBUG] go-api::plugin_community::enable instance ID: %v, name: %v", instanceID, pluginName)
 	path := fmt.Sprintf("/api/instances/%d/plugins/community?async=true", instanceID)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
@@ -96,7 +96,7 @@ func (api *API) readPluginsCommunityWithRetry(instanceID, attempts, sleep int) (
 
 func (api *API) UpdatePluginCommunity(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
-	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool), Async: true}
+	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool)}
 	log.Printf("[DEBUG] go-api::plugin_community::update instance ID: %v, params: %v", instanceID, params)
 	path := fmt.Sprintf("/api/instances/%d/plugins/community?async=true", instanceID)
 	response, err := api.sling.New().Put(path).BodyJSON(pluginParams).Receive(nil, &failed)
@@ -113,10 +113,9 @@ func (api *API) UpdatePluginCommunity(instanceID int, params map[string]interfac
 
 func (api *API) DisablePluginCommunity(instanceID int, pluginName string) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
-	pluginParams := &PluginParams{Async: true}
 	log.Printf("[DEBUG] go-api::plugin_community::disable instance ID: %v, name: %v", instanceID, pluginName)
 	path := fmt.Sprintf("/api/instances/%d/plugins/community/%s?async=true", instanceID, pluginName)
-	response, err := api.sling.New().Delete(path).BodyJSON(pluginParams).Receive(nil, &failed)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 
 	if err != nil {
 		return nil, err

--- a/api/plugins_community.go
+++ b/api/plugins_community.go
@@ -28,7 +28,7 @@ func (api *API) EnablePluginCommunity(instanceID int, pluginName string) (map[st
 	failed := make(map[string]interface{})
 	params := &PluginParams{Name: pluginName, Async: true}
 	log.Printf("[DEBUG] go-api::plugin_community::enable instance ID: %v, name: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins/community", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/plugins/community?async=true", instanceID)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
 
 	if err != nil {
@@ -98,7 +98,7 @@ func (api *API) UpdatePluginCommunity(instanceID int, params map[string]interfac
 	failed := make(map[string]interface{})
 	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool), Async: true}
 	log.Printf("[DEBUG] go-api::plugin_community::update instance ID: %v, params: %v", instanceID, params)
-	path := fmt.Sprintf("/api/instances/%d/plugins/community", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/plugins/community?async=true", instanceID)
 	response, err := api.sling.New().Put(path).BodyJSON(pluginParams).Receive(nil, &failed)
 
 	if err != nil {
@@ -115,7 +115,7 @@ func (api *API) DisablePluginCommunity(instanceID int, pluginName string) (map[s
 	failed := make(map[string]interface{})
 	pluginParams := &PluginParams{Async: true}
 	log.Printf("[DEBUG] go-api::plugin_community::disable instance ID: %v, name: %v", instanceID, pluginName)
-	path := fmt.Sprintf("/api/instances/%d/plugins/community/%s", instanceID, pluginName)
+	path := fmt.Sprintf("/api/instances/%d/plugins/community/%s?async=true", instanceID, pluginName)
 	response, err := api.sling.New().Delete(path).BodyJSON(pluginParams).Receive(nil, &failed)
 
 	if err != nil {

--- a/api/plugins_community.go
+++ b/api/plugins_community.go
@@ -26,7 +26,7 @@ func (api *API) waitUntilPluginUninstalled(instanceID int, pluginName string) (m
 
 func (api *API) EnablePluginCommunity(instanceID int, pluginName string) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
-	params := &PluginParams{Name: pluginName}
+	params := &PluginParams{Name: pluginName, Async: true}
 	log.Printf("[DEBUG] go-api::plugin_community::enable instance ID: %v, name: %v", instanceID, pluginName)
 	path := fmt.Sprintf("/api/instances/%d/plugins/community", instanceID)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
@@ -71,7 +71,6 @@ func (api *API) readPluginsCommunityWithRetry(instanceID, attempts, sleep int) (
 	log.Printf("[DEBUG] go-api::plugin_community::readPluginsCommunityWithRetry instance id: %v", instanceID)
 	path := fmt.Sprintf("/api/instances/%d/plugins/community", instanceID)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::plugin_community::readPluginsCommunityWithRetry data: %v", data)
 
 	if err != nil {
 		return nil, err
@@ -97,7 +96,7 @@ func (api *API) readPluginsCommunityWithRetry(instanceID, attempts, sleep int) (
 
 func (api *API) UpdatePluginCommunity(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
-	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool)}
+	pluginParams := &PluginParams{Name: params["name"].(string), Enabled: params["enabled"].(bool), Async: true}
 	log.Printf("[DEBUG] go-api::plugin_community::update instance ID: %v, params: %v", instanceID, params)
 	path := fmt.Sprintf("/api/instances/%d/plugins/community", instanceID)
 	response, err := api.sling.New().Put(path).BodyJSON(pluginParams).Receive(nil, &failed)
@@ -114,9 +113,10 @@ func (api *API) UpdatePluginCommunity(instanceID int, params map[string]interfac
 
 func (api *API) DisablePluginCommunity(instanceID int, pluginName string) (map[string]interface{}, error) {
 	failed := make(map[string]interface{})
+	pluginParams := &PluginParams{Async: true}
 	log.Printf("[DEBUG] go-api::plugin_community::disable instance ID: %v, name: %v", instanceID, pluginName)
 	path := fmt.Sprintf("/api/instances/%d/plugins/community/%s", instanceID, pluginName)
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	response, err := api.sling.New().Delete(path).BodyJSON(pluginParams).Receive(nil, &failed)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Support to enable/disable plugins through async request, especially useful for multi node clusters.

### Friendly reminders
- [ ] Describe the problem / feature (ideally with [meaningful commit messages](https://tekin.co.uk/2019/02/a-talk-about-revision-histories))
- [ ] Lint rules pass
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] The environment (`heroku config`) has been updated if needed (new `ENV` variables)

### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
