### PR TITLE
Retry VPC peering and wait for status

### DIFF
--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -141,7 +141,6 @@ func (api *API) waitForPeeringStatusWithRetry(path, peeringID string, attempt, s
 		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
-
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 
 	switch {
@@ -161,8 +160,8 @@ func (api *API) waitForPeeringStatusWithRetry(path, peeringID string, attempt, s
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40003:
-			log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry Could not find VPC peering, "+
-				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
+			log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry %s, attempt: %d, until timeout: %d",
+				failed["message"].(string), attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.waitForPeeringStatusWithRetry(path, peeringID, attempt, sleep, timeout)

--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -7,83 +7,20 @@ import (
 	"time"
 )
 
-func (api *API) WaitForPeeringStatus(instanceID int, peeringID string, attempt, sleep, timeout int) (int, error) {
-	time.Sleep(10 * time.Second)
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/status/%v", instanceID, peeringID)
-	return api.waitForPeeringStatusWithRetry(path, attempt, sleep, timeout)
-}
-
-func (api *API) waitForPeeringStatusWithRetry(path string, attempt, sleep, timeout int) (int, error) {
-	log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry path: %s, "+
-		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	if err != nil {
-		return attempt, err
-	}
-
-	switch {
-	case attempt*sleep >= timeout:
-		return attempt, fmt.Errorf("Remove VPC peering failed, reached timeout of %d seconds", timeout)
-	case response.StatusCode == 200:
-		switch data["status"] {
-		case "active", "pending-acceptance":
-			return attempt, nil
-		}
-		// Todo: Check if needed?
-		log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry No status yet, "+
-			"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
-		attempt++
-		time.Sleep(time.Duration(sleep) * time.Second)
-		return api.waitForPeeringStatusWithRetry(path, attempt, sleep, timeout)
-	case response.StatusCode == 400:
-		switch {
-		case failed["error_code"] == nil:
-			break
-		case failed["error_code"].(float64) == 40003:
-			log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry Could not find VPC peering, "+
-				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.waitForPeeringStatusWithRetry(path, attempt, sleep, timeout)
-		}
-	}
-	return attempt, fmt.Errorf("Accept VPC peering failed, status: %v, message: %v", response.StatusCode, failed)
-}
-
-func (api *API) ReadVpcInfo(instanceID int) (map[string]interface{}, error) {
-	// Initiale values, 5 attempts and 20 second sleep
-	return api.readVpcInfoWithRetry(instanceID, 5, 20)
-}
-
-func (api *API) readVpcInfoWithRetry(instanceID, attempts, sleep int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering::info instance id: %v", instanceID)
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/info", instanceID)
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc_peering::info data: %v", data)
-
+func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
+	attempt, err := api.waitForPeeringStatus(instanceID, peeringID, 1, sleep, timeout)
+	log.Printf("[DEBUG] go-api::vpc_peering::accept attempt: %d, sleep: %d, timeout: %d", attempt, sleep, timeout)
 	if err != nil {
 		return nil, err
 	}
+	path := fmt.Sprintf("/api/instances/%v/vpc-peering/request/%v", instanceID, peeringID)
+	return api.retryAcceptVpcPeering(path, attempt, sleep, timeout)
+}
 
-	statusCode := response.StatusCode
-	log.Printf("[DEBUG] go-api::vpc_peering::info statusCode: %d", statusCode)
-	switch {
-	case statusCode == 400:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			if attempts--; attempts > 0 {
-				log.Printf("[INFO] go-api::vpc_peering::info Timeout talking to backend "+
-					"attempts left %d and retry in %d seconds", attempts, sleep)
-				time.Sleep(time.Duration(sleep) * time.Second)
-				return api.readVpcInfoWithRetry(instanceID, attempts, 2*sleep)
-			}
-			return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
-		}
-	}
-	return data, nil
+func (api *API) ReadVpcInfo(instanceID int) (map[string]interface{}, error) {
+	path := fmt.Sprintf("/api/instances/%v/vpc-peering/info", instanceID)
+	// Initiale values, 5 attempts and 20 second sleep
+	return api.readVpcInfoWithRetry(path, 5, 20)
 }
 
 func (api *API) ReadVpcPeeringRequest(instanceID int, peeringID string) (map[string]interface{}, error) {
@@ -96,25 +33,28 @@ func (api *API) ReadVpcPeeringRequest(instanceID int, peeringID string) (map[str
 
 	if err != nil {
 		return nil, err
-	}
-	if response.StatusCode != 200 {
+	} else if response.StatusCode != 200 {
 		return nil, fmt.Errorf("ReadRequest failed, status: %v, message: %s", response.StatusCode, failed)
 	}
 
 	return data, nil
 }
 
-func (api *API) retryAcceptVpcPeering(instanceID int, peeringID string, attempt, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) RemoveVpcPeering(instanceID int, peeringID string, sleep, timeout int) error {
+	path := fmt.Sprintf("/api/instances/%v/vpc-peering/%v", instanceID, peeringID)
+	return api.retryRemoveVpcPeering(path, 1, sleep, timeout)
+}
+
+func (api *API) retryAcceptVpcPeering(path string, attempt, sleep, timeout int) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] go-api::vpc_peering::retryRemoveVpcPeering path: %s, "+
+		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/request/%v", instanceID, peeringID)
 	response, err := api.sling.New().Put(path).Receive(&data, &failed)
 
-	if err != nil {
-		return nil, err
-	}
-
 	switch {
+	case err != nil:
+		return nil, err
 	case response.StatusCode == 200:
 		return data, nil
 	case attempt*sleep >= timeout:
@@ -128,28 +68,47 @@ func (api *API) retryAcceptVpcPeering(instanceID int, peeringID string, attempt,
 				"accept VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.retryAcceptVpcPeering(instanceID, peeringID, attempt, sleep, timeout)
+			return api.retryAcceptVpcPeering(path, attempt, sleep, timeout)
 		}
 	}
+
 	return nil, fmt.Errorf("Accept VPC peering failed, status: %v, message: %s", response.StatusCode, failed)
 }
 
-func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
-	attempt, err := api.WaitForPeeringStatus(instanceID, peeringID, 1, sleep, timeout)
-	log.Printf("[DEBUG] go-api::vpc_peering::accept attempt: %d, sleep: %d, timeout: %d", attempt, sleep, timeout)
-	if err != nil {
+func (api *API) readVpcInfoWithRetry(path string, attempts, sleep int) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] go-api::vpc_peering::readVpcInfoWithRetry path: %s, "+
+		"attempts: %d, sleep: %d", path, attempts, sleep)
+	data := make(map[string]interface{})
+	failed := make(map[string]interface{})
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	log.Printf("[DEBUG] go-api::vpc_peering::info data: %v", data)
+
+	switch {
+	case err != nil:
 		return nil, err
+	case response.StatusCode == 400:
+		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
+			if attempts--; attempts > 0 {
+				log.Printf("[INFO] go-api::vpc_peering::info Timeout talking to backend "+
+					"attempts left %d and retry in %d seconds", attempts, sleep)
+				time.Sleep(time.Duration(sleep) * time.Second)
+				return api.readVpcInfoWithRetry(path, attempts, 2*sleep)
+			}
+			return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
+		}
 	}
-	return api.retryAcceptVpcPeering(instanceID, peeringID, attempt, sleep, timeout)
+
+	return data, nil
 }
 
-func (api *API) retryRemoveVpcPeering(instanceID int, peeringID string, attempt, sleep, timeout int) error {
+func (api *API) retryRemoveVpcPeering(path string, attempt, sleep, timeout int) error {
+	log.Printf("[DEBUG] go-api::vpc_peering::retryRemoveVpcPeering path: %s, "+
+		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
 	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering::remove instance id: %v, peering id: %v", instanceID, peeringID)
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/%v", instanceID, peeringID)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+
 	switch {
-	case err == nil:
+	case err != nil:
 		return err
 	case response.StatusCode == 204:
 		return nil
@@ -164,12 +123,51 @@ func (api *API) retryRemoveVpcPeering(instanceID int, peeringID string, attempt,
 				"removing VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.retryRemoveVpcPeering(instanceID, peeringID, attempt, sleep, timeout)
+			return api.retryRemoveVpcPeering(path, attempt, sleep, timeout)
 		}
 	}
+
 	return fmt.Errorf("Remove VPC peering failed, status: %v, message: %s", response.StatusCode, failed)
 }
 
-func (api *API) RemoveVpcPeering(instanceID int, peeringID string, sleep, timeout int) error {
-	return api.retryRemoveVpcPeering(instanceID, peeringID, 1, sleep, timeout)
+func (api *API) waitForPeeringStatus(instanceID int, peeringID string, attempt, sleep, timeout int) (int, error) {
+	time.Sleep(10 * time.Second)
+	path := fmt.Sprintf("/api/instances/%v/vpc-peering/status/%v", instanceID, peeringID)
+	return api.waitForPeeringStatusWithRetry(path, peeringID, attempt, sleep, timeout)
+}
+
+func (api *API) waitForPeeringStatusWithRetry(path, peeringID string, attempt, sleep, timeout int) (int, error) {
+	log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry path: %s "+
+		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
+	data := make(map[string]interface{})
+	failed := make(map[string]interface{})
+
+	response, err := api.sling.New().Path(path).Receive(&data, &failed)
+
+	switch {
+	case err != nil:
+		return attempt, err
+	case attempt*sleep >= timeout:
+		return attempt, fmt.Errorf("Accept VPC peering failed, reached timeout of %d seconds", timeout)
+	case response.StatusCode == 200:
+		switch data["status"] {
+		case "active", "pending-acceptance":
+			return attempt, nil
+		case "deleted":
+			return attempt, fmt.Errorf("Peering: %s has been deleted", peeringID)
+		}
+	case response.StatusCode == 400:
+		switch {
+		case failed["error_code"] == nil:
+			break
+		case failed["error_code"].(float64) == 40003:
+			log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry Could not find VPC peering, "+
+				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
+			attempt++
+			time.Sleep(time.Duration(sleep) * time.Second)
+			return api.waitForPeeringStatusWithRetry(path, peeringID, attempt, sleep, timeout)
+		}
+	}
+
+	return attempt, fmt.Errorf("Accept VPC peering failed, status: %v, message: %v", response.StatusCode, failed)
 }

--- a/api/vpc_peering_withvpcid.go
+++ b/api/vpc_peering_withvpcid.go
@@ -9,26 +9,10 @@ import (
 	"time"
 )
 
-func (api *API) waitForPeeringStatusWithVpcId(vpcID, peeringID string) (map[string]interface{}, error) {
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::waitForPeeringStatus instance id: %s, peering id: %s", vpcID, peeringID)
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	for {
-		time.Sleep(10 * time.Second)
-		path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/status/%s", vpcID, peeringID)
-		response, err := api.sling.New().Path(path).Receive(&data, &failed)
-
-		if err != nil {
-			return nil, err
-		}
-		if response.StatusCode != 200 {
-			return nil, fmt.Errorf("Wait for peering status failed, status: %v, message: %s", response.StatusCode, failed)
-		}
-		switch data["status"] {
-		case "active", "pending-acceptance":
-			return data, nil
-		}
-	}
+func (api *API) WaitForPeeringStatusWithVpcID(vpcID, peeringID string, attempt, sleep, timeout int) (int, error) {
+	time.Sleep(10 * time.Second)
+	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/status/%s", vpcID, peeringID)
+	return api.waitForPeeringStatusWithRetry(path, attempt, sleep, timeout)
 }
 
 func (api *API) ReadVpcInfoWithVpcId(vpcID string) (map[string]interface{}, error) {

--- a/api/vpc_peering_withvpcid.go
+++ b/api/vpc_peering_withvpcid.go
@@ -5,49 +5,22 @@ package api
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 )
 
-func (api *API) WaitForPeeringStatusWithVpcID(vpcID, peeringID string, attempt, sleep, timeout int) (int, error) {
-	time.Sleep(10 * time.Second)
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/status/%s", vpcID, peeringID)
-	return api.waitForPeeringStatusWithRetry(path, attempt, sleep, timeout)
-}
-
-func (api *API) ReadVpcInfoWithVpcId(vpcID string) (map[string]interface{}, error) {
-	// Initiale values, 5 attempts and 20 second sleep
-	return api.readVpcInfoWithRetryWithVpcId(vpcID, 5, 20)
-}
-
-func (api *API) readVpcInfoWithRetryWithVpcId(vpcID string, attempts, sleep int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::info vpc id: %s", vpcID)
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/info", vpcID)
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::info data: %v", data)
-
+func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
+	attempt, err := api.waitForPeeringStatusWithVpcID(vpcID, peeringID, 1, sleep, timeout)
 	if err != nil {
 		return nil, err
 	}
+	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/request/%s", vpcID, peeringID)
+	return api.retryAcceptVpcPeering(path, attempt, sleep, timeout)
+}
 
-	statusCode := response.StatusCode
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::info statusCode: %d", statusCode)
-	switch {
-	case statusCode == 400:
-		// Todo: Implement error code to be checked instead. To avoid using string comparison.
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			if attempts--; attempts > 0 {
-				log.Printf("[INFO] go-api::vpc_peering_withvpcid::info Timeout talking to backend "+
-					"attempts left %d and retry in %d seconds", attempts, sleep)
-				time.Sleep(time.Duration(sleep) * time.Second)
-				return api.readVpcInfoWithRetryWithVpcId(vpcID, attempts, 2*sleep)
-			}
-			return nil, fmt.Errorf("ReadInfo failed, status: %v, message: %s", response.StatusCode, failed)
-		}
-	}
-	return data, nil
+func (api *API) ReadVpcInfoWithVpcId(vpcID string) (map[string]interface{}, error) {
+	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/info", vpcID)
+	// Initiale values, 5 attempts and 20 second sleep
+	return api.readVpcInfoWithRetry(path, 5, 20)
 }
 
 func (api *API) ReadVpcPeeringRequestWithVpcId(vpcID, peeringID string) (map[string]interface{}, error) {
@@ -60,82 +33,20 @@ func (api *API) ReadVpcPeeringRequestWithVpcId(vpcID, peeringID string) (map[str
 
 	if err != nil {
 		return nil, err
-	}
-	if response.StatusCode != 200 {
+	} else if response.StatusCode != 200 {
 		return nil, fmt.Errorf("ReadRequest failed, status: %v, message: %s", response.StatusCode, failed)
 	}
 
 	return data, nil
 }
 
-func (api *API) retryAcceptVpcPeeringWithVpcId(vpcID, peeringID string, attempt, sleep, timeout int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/request/%s", vpcID, peeringID)
-	response, err := api.sling.New().Put(path).Receive(&data, &failed)
-
-	if err != nil {
-		return nil, err
-	}
-
-	switch {
-	case response.StatusCode == 200:
-		return data, nil
-	case attempt*sleep >= timeout:
-		return nil, fmt.Errorf("Accept VPC peering with vpcId failed, reached timeout of %d seconds", timeout)
-	case response.StatusCode == 400:
-		switch {
-		case failed["error_code"] == nil:
-			break
-		case failed["error_code"].(float64) == 40001:
-			log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::accept firewall not finished configuring will retry "+
-				"accept VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.retryAcceptVpcPeeringWithVpcId(vpcID, peeringID, attempt, sleep, timeout)
-		}
-	}
-	return nil, fmt.Errorf("Accept VPC peering with vpcId failed, status: %v, message: %s", response.StatusCode, failed)
-}
-
-func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
-	attempt, err := api.WaitForPeeringStatusWithVpcID(vpcID, peeringID, 1, sleep, timeout)
-	if err != nil {
-		return nil, err
-	}
-	return api.retryAcceptVpcPeeringWithVpcId(vpcID, peeringID, attempt, sleep, timeout)
-}
-
-func (api *API) retryRemoveVpcPeeringWithVpcId(vpcID, peeringID string, attempt, sleep, timeout int) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::remove vpc id: %s, peering id: %s", vpcID, peeringID)
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peeringID)
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
-
-	if err != nil {
-		return err
-	}
-
-	switch {
-	case response.StatusCode == 204:
-		return nil
-	case attempt*sleep >= timeout:
-		return fmt.Errorf("Remove VPC peering with vpcID failed, reached timeout of %d seconds", timeout)
-	case response.StatusCode == 400:
-		switch {
-		case failed["error_code"] == nil:
-			break
-		case failed["error_code"].(float64) == 40001:
-			log.Printf("[DEBUG] go-api::vpc_peering::remove firewall not finished configuring will retry "+
-				"accept VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.retryRemoveVpcPeeringWithVpcId(vpcID, peeringID, attempt, sleep, timeout)
-		}
-	}
-	return fmt.Errorf("Remove VPC peering with vpcId failed, status: %v, message: %s", response.StatusCode, failed)
-}
-
 func (api *API) RemoveVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) error {
-	return api.retryRemoveVpcPeeringWithVpcId(vpcID, peeringID, 1, sleep, timeout)
+	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peeringID)
+	return api.retryRemoveVpcPeering(path, 1, sleep, timeout)
+}
+
+func (api *API) waitForPeeringStatusWithVpcID(vpcID, peeringID string, attempt, sleep, timeout int) (int, error) {
+	time.Sleep(10 * time.Second)
+	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/status/%s", vpcID, peeringID)
+	return api.waitForPeeringStatusWithRetry(path, peeringID, attempt, sleep, timeout)
 }


### PR DESCRIPTION
Issue reported when VPC peering on multiple instances and VPC peering status fails to find correct peering. Fails due to cloud resource not yet updated. Include wait for peering status into the provider resource and the configured sleep and timeout [arguments.](https://github.com/cloudamqp/terraform-provider-cloudamqp/blob/master/cloudamqp/resource_cloudamqp_vpc_peering.go#L40-L51) 

- Sort func. in alphabetical order.
- Put "public" on top, "private" at the bottom. (Still use the same package-name so all func. are accessible).
- Retry wait for peering status before accepting peering request.
- Share configured sleep/timeout when accepting peering (between wait and accept request)
- Re-use common func. between instanceID and vpcID peerings. Concat into path string.
- Refactor other retry func. from if/else to switch statement.
- Use early exit in retry func.

### Friendly reminders
- [X] Describe the problem / feature (ideally with [meaningful commit messages](https://tekin.co.uk/2019/02/a-talk-about-revision-histories))
- [ ] Lint rules pass
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] The environment (`heroku config`) has been updated if needed (new `ENV` variables)

### Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
