### PR TITLE
Add new endpoints to support PrivateLink

### DIFF
--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+func (api *API) EnablePrivatelink(instanceID int) error {
+	// TODO: Check if instance have VPC already?
+	// TODO: Otherwise just need to first enable it before moving on.
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
+	)
+	response, err := api.sling.New().Post(path).Receive(nil, &failed)
+	if err != nil {
+		return err
+	} else if response.StatusCode == 200 {
+		return api.waitForEnablePrivatelinkWithRetry(instanceID, 5, 20)
+	}
+	return fmt.Errorf("Enable PrivateLink failed, status: %v, message: %s", response.StatusCode, failed)
+}
+
+func (api *API) ReadPrivatelink(instanceID int) (map[string]interface{}, error) {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
+	)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
+		return nil, err
+	} else if response.StatusCode == 200 {
+		return data, nil
+	}
+	return nil, fmt.Errorf("Read PrivateLink failed, status: %v, message: %s", response.StatusCode, failed)
+}
+
+func (api *API) UpdatePrivatelink(instanceID int, params map[string]interface{}) error {
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
+	)
+	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
+	if err != nil {
+		return err
+	} else if response.StatusCode == 200 {
+		return nil
+	}
+	return fmt.Errorf("Update Privatelink failed, status: %v, message: %s", response.StatusCode, failed)
+}
+
+func (api *API) DisablePrivatelink(instanceID int) error {
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
+	)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	if err != nil {
+		return err
+	} else if response.StatusCode == 200 {
+		return nil
+	}
+	return fmt.Errorf("Delete Privatelink failed, status: %v, message: %s", response.StatusCode, failed)
+}
+
+func (api *API) waitForEnablePrivatelinkWithRetry(instanceID, attempts, sleep int) error {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
+	)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
+		return err
+	}
+
+	switch response.StatusCode {
+	case 200:
+		switch data["status"].(string) {
+		case "enabled":
+			return nil
+		case "pending":
+			if attempts--; attempts > 0 {
+				log.Printf("[INFO] go-api::privatelink::waitForEnablePrivatelink "+
+					"attempts left %d and retry in %d seconds", attempts, sleep)
+				time.Sleep(time.Duration(sleep) * time.Second)
+				return api.waitForEnablePrivatelinkWithRetry(instanceID, attempts, 2*sleep)
+			}
+		}
+	}
+	return fmt.Errorf("Wait for enable PrivateLink failed, status: %v, message: %s",
+		response.StatusCode, failed)
+}

--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -24,7 +24,7 @@ func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{
 		return err
 	}
 
-	if response.StatusCode == 200 {
+	if response.StatusCode == 204 {
 		return api.waitForEnablePrivatelinkWithRetry(instanceID, 1, sleep, timeout)
 	} else {
 		return fmt.Errorf("Enable PrivateLink failed, status: %v, message: %s",
@@ -65,7 +65,7 @@ func (api *API) UpdatePrivatelink(instanceID int, params map[string][]interface{
 		return err
 	}
 
-	if response.StatusCode == 200 {
+	if response.StatusCode == 204 {
 		return nil
 	} else {
 		return fmt.Errorf("Update Privatelink failed, status: %v, message: %s",
@@ -85,7 +85,7 @@ func (api *API) DisablePrivatelink(instanceID int) error {
 		return err
 	}
 
-	if response.StatusCode == 200 {
+	if response.StatusCode == 204 {
 		return nil
 	} else {
 		return fmt.Errorf("Disable Privatelink failed, status: %v, message: %s",

--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -17,10 +17,11 @@ func (api *API) EnablePrivatelink(instanceID, sleep, timeout int) error {
 		err      error
 		response *http.Response
 	)
-	log.Printf("[DEBUG] PrivateLink: Enable PrivateLink")
+
 	if err = api.enableVPC(instanceID); err != nil {
 		return err
 	}
+
 	if response, err = api.sling.New().Post(path).Receive(nil, &failed); err != nil {
 		return err
 	} else if response.StatusCode == 200 {
@@ -38,6 +39,7 @@ func (api *API) ReadPrivatelink(instanceID int) (map[string]interface{}, error) 
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
+
 	if response, err := api.sling.New().Get(path).Receive(&data, &failed); err != nil {
 		return nil, err
 	} else if response.StatusCode == 200 {
@@ -54,6 +56,7 @@ func (api *API) UpdatePrivatelink(instanceID int, params map[string][]interface{
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
+
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -71,6 +74,7 @@ func (api *API) DisablePrivatelink(instanceID int) error {
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
+
 	if response, err := api.sling.New().Delete(path).Receive(nil, &failed); err != nil {
 		return err
 	} else if response.StatusCode == 200 {
@@ -90,6 +94,7 @@ func (api *API) waitForEnablePrivatelinkWithRetry(instanceID, attempt, sleep, ti
 		response *http.Response
 		err      error
 	)
+
 	if response, err = api.sling.New().Get(path).Receive(&data, &failed); err != nil {
 		return err
 	} else if attempt*sleep > timeout {
@@ -110,6 +115,7 @@ func (api *API) waitForEnablePrivatelinkWithRetry(instanceID, attempt, sleep, ti
 			return api.waitForEnablePrivatelinkWithRetry(instanceID, attempt, sleep, timeout)
 		}
 	}
+
 	return fmt.Errorf("Wait for enable PrivateLink failed, status: %v, message: %s",
 		response.StatusCode, failed)
 }
@@ -121,6 +127,7 @@ func (api *API) enableVPC(instanceID int) error {
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/vpc", instanceID)
 	)
+
 	data, _ := api.ReadInstance(fmt.Sprintf("%d", instanceID))
 	if data["vpc"] == nil {
 		if response, err := api.sling.New().Put(path).Receive(nil, &failed); err != nil {
@@ -133,6 +140,7 @@ func (api *API) enableVPC(instanceID int) error {
 				response.StatusCode, failed)
 		}
 	}
+
 	log.Printf("[DEBUG] PrivateLink: VPC features already enabled")
 	return nil
 }

--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"time"
 )
 
@@ -12,19 +11,20 @@ import (
 // Wait until finished with configureable sleep and timeout.
 func (api *API) EnablePrivatelink(instanceID, sleep, timeout int) error {
 	var (
-		failed   map[string]interface{}
-		path     = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
-		err      error
-		response *http.Response
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
-	if err = api.enableVPC(instanceID); err != nil {
+	if err := api.enableVPC(instanceID); err != nil {
 		return err
 	}
 
-	if response, err = api.sling.New().Post(path).Receive(nil, &failed); err != nil {
+	response, err := api.sling.New().Post(path).Receive(nil, &failed)
+	if err != nil {
 		return err
-	} else if response.StatusCode == 200 {
+	}
+
+	if response.StatusCode == 200 {
 		return api.waitForEnablePrivatelinkWithRetry(instanceID, 1, sleep, timeout)
 	} else {
 		return fmt.Errorf("Enable PrivateLink failed, status: %v, message: %s",
@@ -40,9 +40,12 @@ func (api *API) ReadPrivatelink(instanceID int) (map[string]interface{}, error) 
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
-	if response, err := api.sling.New().Get(path).Receive(&data, &failed); err != nil {
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
 		return nil, err
-	} else if response.StatusCode == 200 {
+	}
+
+	if response.StatusCode == 200 {
 		return data, nil
 	} else {
 		return nil, fmt.Errorf("Read PrivateLink failed, status: %v, message: %s",
@@ -60,7 +63,9 @@ func (api *API) UpdatePrivatelink(instanceID int, params map[string][]interface{
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err
-	} else if response.StatusCode == 200 {
+	}
+
+	if response.StatusCode == 200 {
 		return nil
 	} else {
 		return fmt.Errorf("Update Privatelink failed, status: %v, message: %s",
@@ -75,9 +80,12 @@ func (api *API) DisablePrivatelink(instanceID int) error {
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
-	if response, err := api.sling.New().Delete(path).Receive(nil, &failed); err != nil {
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	if err != nil {
 		return err
-	} else if response.StatusCode == 200 {
+	}
+
+	if response.StatusCode == 200 {
 		return nil
 	} else {
 		return fmt.Errorf("Disable Privatelink failed, status: %v, message: %s",
@@ -88,14 +96,13 @@ func (api *API) DisablePrivatelink(instanceID int) error {
 // waitForEnablePrivatelinkWithRetry: Wait until status change from pending to enable
 func (api *API) waitForEnablePrivatelinkWithRetry(instanceID, attempt, sleep, timeout int) error {
 	var (
-		data     map[string]interface{}
-		failed   map[string]interface{}
-		path     = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
-		response *http.Response
-		err      error
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
-	if response, err = api.sling.New().Get(path).Receive(&data, &failed); err != nil {
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
 		return err
 	} else if attempt*sleep > timeout {
 		return fmt.Errorf("Enable PrivateLink failed, reached timeout of %d seconds", timeout)
@@ -130,9 +137,12 @@ func (api *API) enableVPC(instanceID int) error {
 
 	data, _ := api.ReadInstance(fmt.Sprintf("%d", instanceID))
 	if data["vpc"] == nil {
-		if response, err := api.sling.New().Put(path).Receive(nil, &failed); err != nil {
+		response, err := api.sling.New().Put(path).Receive(nil, &failed)
+		if err != nil {
 			return err
-		} else if response.StatusCode == 200 {
+		}
+
+		if response.StatusCode == 200 {
 			log.Printf("[DEBUG] PrivateLink: VPC features enabled")
 			return nil
 		} else {

--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -9,7 +9,7 @@ import (
 // EnablePrivatelink: Enable PrivateLink and wait until finished.
 // Need to enable VPC for an instance, if no standalone VPC used.
 // Wait until finished with configureable sleep and timeout.
-func (api *API) EnablePrivatelink(instanceID, sleep, timeout int) error {
+func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{}, sleep, timeout int) error {
 	var (
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
@@ -19,7 +19,7 @@ func (api *API) EnablePrivatelink(instanceID, sleep, timeout int) error {
 		return err
 	}
 
-	response, err := api.sling.New().Post(path).Receive(nil, &failed)
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
New endpoints to support PrivateLink for the updated API backend.

Make sure VPC is enabled before enable PrivateLink!

### Friendly reminders
- [ ] Describe the problem / feature (ideally with [meaningful commit messages](https://tekin.co.uk/2019/02/a-talk-about-revision-histories))
- [ ] Lint rules pass
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] The environment (`heroku config`) has been updated if needed (new `ENV` variables)

### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
