### PR TITLE
Add retry when resizing disk

### DIFF
--- a/api/disk.go
+++ b/api/disk.go
@@ -28,7 +28,7 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 	if err != nil {
 		return nil, err
 	} else if attempt*sleep > timeout {
-		return nil, fmt.Errorf("Wait until resize disk failed, reached timeout of %d seconds", timeout)
+		return nil, fmt.Errorf("Resize disk timeout reached after %d seconds", timeout)
 	}
 
 	switch response.StatusCode {

--- a/api/disk.go
+++ b/api/disk.go
@@ -33,7 +33,7 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 
 	switch response.StatusCode {
 	case 200:
-		if err = api.waitUntilAllNodesReady(id); err != nil {
+		if err = api.waitUntilAllNodesReadyWithTimeout(id, attempt, sleep, timeout); err != nil {
 			return nil, err
 		}
 		return data, nil

--- a/api/disk.go
+++ b/api/disk.go
@@ -29,13 +29,13 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 		return nil, err
 	}
 
-	switch {
-	case response.StatusCode == 200:
+	switch response.StatusCode {
+	case 200:
 		if err = api.waitUntilAllNodesReady(id); err != nil {
 			return nil, err
 		}
 		return data, nil
-	case response.StatusCode == 400:
+	case 400:
 		switch {
 		case failed["error_code"] == nil:
 			break

--- a/api/disk.go
+++ b/api/disk.go
@@ -27,6 +27,8 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
+	} else if attempt*sleep > timeout {
+		return nil, fmt.Errorf("Wait until resize disk failed, reached timeout of %d seconds", timeout)
 	}
 
 	switch response.StatusCode {

--- a/api/disk.go
+++ b/api/disk.go
@@ -33,7 +33,7 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 
 	switch response.StatusCode {
 	case 200:
-		if err = api.waitUntilAllNodesReadyWithTimeout(id, attempt, sleep, timeout); err != nil {
+		if err = api.waitWithTimeoutUntilAllNodesConfigured(id, attempt, sleep, timeout); err != nil {
 			return nil, err
 		}
 		return data, nil

--- a/api/disk.go
+++ b/api/disk.go
@@ -53,5 +53,5 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 			}
 		}
 	}
-	return nil, fmt.Errorf("Resize disk failed, status: %v, message: %s", response.StatusCode, failed)
+	return nil, fmt.Errorf("Resize disk failed, status: %v, message: %s", response.StatusCode, failed["error"])
 }

--- a/api/instance.go
+++ b/api/instance.go
@@ -56,35 +56,34 @@ func (api *API) waitUntilAllNodesReady(instanceID string) error {
 	}
 }
 
-func (api *API) waitUntilAllNodesReadyWithTimeout(instanceID string, attempt, sleep, timeout int) error {
+func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attempt, sleep, timeout int) error {
 	var (
 		data   []map[string]interface{}
 		failed map[string]interface{}
 		path   = fmt.Sprintf("api/instances/%v/nodes", instanceID)
 	)
-	log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReadyWithTimeout not yet ready, "+
+	log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured not yet ready, "+
 		" will try again, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 
 	_, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
-		log.Printf("[ERROR] go-api::instance::waitUntilAllNodesReadyWithTimeout error: %v", err)
 		return err
 	} else if attempt*sleep > timeout {
-		return fmt.Errorf("Wait until all nodes ready reached timeout of %d seconds", timeout)
+		return fmt.Errorf("All nodes configured timeout reached after %d seconds", timeout)
 	}
 
 	ready := true
 	for _, node := range data {
-		log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReadyWithTimeout ready: %v, configured: %v", ready, node["configured"])
+		log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured ready: %v, configured: %v", ready, node["configured"])
 		ready = ready && node["configured"].(bool)
 	}
-	log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReadyWithTimeout ready: %v", ready)
+	log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured ready: %v", ready)
 	if ready {
 		return nil
 	}
 	attempt++
 	time.Sleep(time.Duration(sleep) * time.Second)
-	return api.waitUntilAllNodesReadyWithTimeout(instanceID, attempt, sleep, timeout)
+	return api.waitWithTimeoutUntilAllNodesConfigured(instanceID, attempt, sleep, timeout)
 }
 
 func (api *API) waitUntilDeletion(instanceID string) error {


### PR DESCRIPTION
### WHY are these changes introduced?

To enable support for multiple platforms: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/194
We need to poll the resize disk action, to be sure that the resize have been finished. 

Noticed when expanding disk for GCE, and when swapping disk for all allowed platform.

### WHAT is this pull request doing?

Adds retry polling when resizing disk action have been invoked

### HOW can this pull request be tested?

Manual create CloudAMQP instances with the provider and either resize disk in one go, or divide it into multiple attempts. 