### PR TITLE
Add new endpoints to support AWS EventBridge

### DIFF
--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"fmt"
+	"log"
+)
+
+func (api *API) CreateAwsEventBridge(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/eventbridges", instanceID)
+	)
+
+	log.Printf("[DEBUG] go-api::aws-eventbridge::create instance ID: %d, params: %v", instanceID, params)
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != 201 {
+		return nil, fmt.Errorf("Failed to create AWS EventBridge, status: %v, message: %s",
+			response.StatusCode, failed)
+	}
+
+	return data, nil
+}
+
+func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (map[string]interface{}, error) {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/eventbridges/%s", instanceID, eventbridgeID)
+	)
+
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("Failed to read AWS EventBridge, status: %v, message: %s",
+			response.StatusCode, failed)
+	}
+
+	return extractInfo(data["url"].(string)), nil
+}
+
+func (api *API) ReadAwsEventBridges(instanceID int) (map[string]interface{}, error) {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/eventbridges", instanceID)
+	)
+
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("Failed to read AWS EventBridges, status: %v, message: %s",
+			response.StatusCode, failed)
+	}
+
+	return extractInfo(data["url"].(string)), nil
+}
+
+func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error {
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/eventbridges/%s", instanceID, eventbridgeID)
+	)
+
+	log.Printf("[DEBUG] go-api::aws-eventbridge::delete instance id: %d, eventbridge id: %s", instanceID, eventbridgeID)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != 200 {
+		return fmt.Errorf("Failed to delete AWS EventBridge, status: %v, message: %s", response.StatusCode, failed)
+	}
+
+	return nil
+}

--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -81,7 +81,7 @@ func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error
 	if err != nil {
 		return err
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != 204 {
 		return fmt.Errorf("Failed to delete AWS EventBridge, status: %v, message: %s", response.StatusCode, failed)
 	}
 

--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -81,9 +81,14 @@ func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error
 	if err != nil {
 		return err
 	}
-	if response.StatusCode != 204 {
-		return fmt.Errorf("Failed to delete AWS EventBridge, status: %v, message: %s", response.StatusCode, failed)
+
+	switch response.StatusCode {
+	case 204:
+		return nil
+	case 404:
+		// AWS EventBridge not found in the backend. Silent let the resource be deleted.
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("Failed to delete AWS EventBridge, status: %v, message: %s", response.StatusCode, failed)
 }

--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"log"
+	"strconv"
 )
 
 func (api *API) CreateAwsEventBridge(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
@@ -20,6 +21,12 @@ func (api *API) CreateAwsEventBridge(instanceID int, params map[string]interface
 	if response.StatusCode != 201 {
 		return nil, fmt.Errorf("Failed to create AWS EventBridge, status: %v, message: %s",
 			response.StatusCode, failed)
+	}
+	if id, ok := data["id"]; ok {
+		data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
+		log.Printf("[DEBUG] go-api::aws-eventbridge::create EventBridge identifier: %v", data["id"])
+	} else {
+		return nil, fmt.Errorf("go-api::aws-eventbridge::create Invalid identifier: %v", data["id"])
 	}
 
 	return data, nil

--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -48,7 +48,7 @@ func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (map[st
 			response.StatusCode, failed)
 	}
 
-	return extractInfo(data["url"].(string)), nil
+	return data, nil
 }
 
 func (api *API) ReadAwsEventBridges(instanceID int) (map[string]interface{}, error) {
@@ -67,7 +67,7 @@ func (api *API) ReadAwsEventBridges(instanceID int) (map[string]interface{}, err
 			response.StatusCode, failed)
 	}
 
-	return extractInfo(data["url"].(string)), nil
+	return data, nil
 }
 
 func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error {


### PR DESCRIPTION
### WHY are these changes introduced?

Enables requests to our backend, to create new AWS EventBridges. 

Reference: [Trello](https://trello.com/c/gMnHce28/234-support-aws-eventbridge-in-tf-provider)

### WHAT is this pull request doing?

Adds new CRD endpoints to support AWS EventBridge.

Also includes retrieving all AWS EventBridges for an account. If a data source should be used.

### HOW can this pull request be tested?

Manual test with new resource in our CloudAMQP Terraform provider, together with CloudAMQP-API updates.
- [terraform-provider-cloudamqp](https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/192)
- [cloudamqp-api](https://github.com/84codes/cloudamqp-api/pull/367)



