### PR TITLE
Add new endpoints to support backend validation

### DIFF
--- a/api/metadata.go
+++ b/api/metadata.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"fmt"
+)
+
+type Plan struct {
+	Name    string `json:"name"`
+	Backend string `json:"backend"`
+	Shared  bool   `json:"shared"`
+}
+
+type Region struct {
+	Provider string `json:"provider"`
+	Region   string `json:"region"`
+}
+
+func (api *API) ValidatePlan(name string) error {
+	var (
+		data   []Plan
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/plans")
+	)
+
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != 200 {
+		return fmt.Errorf("%s", failed["message"].(string))
+	}
+
+	for _, plan := range data {
+		if name == plan.Name {
+			return nil
+		}
+	}
+	return fmt.Errorf("Subscription plan: %s is not valid", name)
+}
+
+func (api *API) ValidateRegion(region string) error {
+	var (
+		data     []Region
+		failed   map[string]interface{}
+		path     = fmt.Sprintf("api/regions")
+		platform string
+	)
+
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != 200 {
+		return fmt.Errorf("%s", failed["message"].(string))
+	}
+
+	for _, v := range data {
+		platform = fmt.Sprintf("%s::%s", v.Provider, v.Region)
+		if region == platform {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Provider & region: %s is not valid", region)
+}


### PR DESCRIPTION
### WHY are these changes introduced?

To be able to support backend validation. New endpoints needed to fetch team based plans and regions information.

### WHAT is this pull request doing?

Adds new endpoints to fetch information about
- plans
- regions
- validate if two plans are shared/dedicated resp.

### HOW can this pull request be tested?

Manual run with https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/201
