### PR TITLE
Don't wait on state change for required plugin

### DIFF
--- a/api/plugins.go
+++ b/api/plugins.go
@@ -21,6 +21,9 @@ func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enable
 		if err != nil {
 			return nil, err
 		}
+		if response["required"] != nil && response["required"] != false {
+			return response, nil
+		}
 		if response["enabled"] == enabled {
 			return response, nil
 		}


### PR DESCRIPTION
### WHY are these changes introduced?

When enable/disable plugins in async way, we wait for state to change in order to know the action has been done. While plugins we choose to be mandatory cannot be enabled/disabled by our users. Bug reported: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/227 about stuck in destroy loop waiting for change. 

### WHAT is this pull request doing?

Check if plugin is required while waiting on state change. If true, don't wait on state change.

### HOW can this pull request be tested?

Destroy a plugin resource with a mandatory plugin (rabbitmq_prometheus) with a none developer user.
