### PR TITLE
Configurable wait on GCP Peering status

### DIFF
--- a/api/vpc_gcp_peering.go
+++ b/api/vpc_gcp_peering.go
@@ -54,13 +54,15 @@ func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface
 }
 
 func (api *API) ReadVpcGcpPeering(instanceID int, peerID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%v/vpc-peering", instanceID)
+	)
+
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering::read instance_id: %v, peer_id: %v", instanceID, peerID)
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering", instanceID)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering::read data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
@@ -76,11 +78,13 @@ func (api *API) UpdateVpcGcpPeering(instanceID int, peerID string) (map[string]i
 }
 
 func (api *API) RemoveVpcGcpPeering(instanceID int, peerID string) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering::remove instance id: %v, peering id: %v", instanceID, peerID)
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/%v", instanceID, peerID)
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%v/vpc-peering/%v", instanceID, peerID)
+	)
 
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::remove instance id: %v, peering id: %v", instanceID, peerID)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
 	}
@@ -96,13 +100,15 @@ func (api *API) ReadVpcGcpInfo(instanceID int) (map[string]interface{}, error) {
 }
 
 func (api *API) readVpcGcpInfoWithRetry(instanceID, attempts, sleep int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%v/vpc-peering/info", instanceID)
+	)
+
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering::info instance id: %v", instanceID)
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/info", instanceID)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering::info data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}

--- a/api/vpc_gcp_peering.go
+++ b/api/vpc_gcp_peering.go
@@ -29,13 +29,16 @@ func (api *API) waitForGcpPeeringStatus(instanceID int, peerID string) error {
 	}
 }
 
-func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering::request params: %v", params)
-	path := fmt.Sprintf("api/instances/%v/vpc-peering", instanceID)
-	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
+func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface{},
+	waitOnStatus bool) (map[string]interface{}, error) {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%v/vpc-peering", instanceID)
+	)
 
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering::request params: %v", params)
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +46,10 @@ func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface
 		return nil, fmt.Errorf("request VPC peering failed, status: %v, message: %s", response.StatusCode, failed)
 	}
 
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering::request waiting for active state")
-	api.waitForGcpPeeringStatus(instanceID, data["peering"].(string))
+	if waitOnStatus {
+		log.Printf("[DEBUG] go-api::vpc_gcp_peering::request waiting for active state")
+		api.waitForGcpPeeringStatus(instanceID, data["peering"].(string))
+	}
 	return data, nil
 }
 

--- a/api/vpc_gcp_peering_withvpcid.go
+++ b/api/vpc_gcp_peering_withvpcid.go
@@ -56,13 +56,15 @@ func (api *API) RequestVpcGcpPeeringWithVpcId(vpcID string, params map[string]in
 }
 
 func (api *API) ReadVpcGcpPeeringWithVpcId(vpcID, peerID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering", vpcID)
+	)
+
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::read instance_id: %s, peer_id: %s", vpcID, peerID)
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering", vpcID)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::read data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +80,13 @@ func (api *API) UpdateVpcGcpPeeringWithVpcId(vpcID, peerID string) (map[string]i
 }
 
 func (api *API) RemoveVpcGcpPeeringWithVpcId(vpcID, peerID string) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::remove vpc id: %s, peering id: %s", vpcID, peerID)
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peerID)
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peerID)
+	)
 
+	log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::remove vpc id: %s, peering id: %s", vpcID, peerID)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
 	}
@@ -98,13 +102,15 @@ func (api *API) ReadVpcGcpInfoWithVpcId(vpcID string) (map[string]interface{}, e
 }
 
 func (api *API) readVpcGcpInfoWithRetryWithVpcId(vpcID string, attempts, sleep int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering/info", vpcID)
+	)
+
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::info vpc id: %s", vpcID)
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/info", vpcID)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::info data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### WHY are these changes introduced?

Provider feature request to be able to configure the need to wait for the peering status.

### WHAT is this pull request doing?

Check `waitOnStatus` to wait on peering status or not.

### HOW can this pull request be tested?

Used together with provider PR: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/228 and peer against another VPC in GCP.

