### PR TITLE
Make plugin retries configurable through input parameters

### DIFF
--- a/api/plugins_community.go
+++ b/api/plugins_community.go
@@ -51,7 +51,7 @@ func (api *API) InstallPluginCommunity(instanceID int, pluginName string, sleep,
 	return api.waitUntilPluginChanged(instanceID, pluginName, true, sleep, timeout)
 }
 
-// ReadPlugin reads a specific community plugin from an instance.
+// ReadPluginCommunity reads a specific community plugin from an instance.
 func (api *API) ReadPluginCommunity(instanceID int, pluginName string, sleep, timeout int) (
 	map[string]interface{}, error) {
 

--- a/api/plugins_community.go
+++ b/api/plugins_community.go
@@ -7,26 +7,7 @@ import (
 	"time"
 )
 
-// waitUntilPluginUninstalled wait until a community plugin been uninstalled.
-func (api *API) waitUntilPluginUninstalled(instanceID int, pluginName string, sleep, timeout int) (
-	map[string]interface{}, error) {
-
-	log.Printf("[DEBUG] go-api::plugin_community::waitUntilPluginUninstalled instance id: %v, name: %v",
-		instanceID, pluginName)
-	for {
-		time.Sleep(time.Duration(sleep) * time.Second)
-		response, err := api.ReadPlugin(instanceID, pluginName, sleep, timeout)
-
-		if err != nil {
-			return nil, err
-		}
-		if len(response) == 0 {
-			return response, nil
-		}
-	}
-}
-
-// InstallPlugin install a community plugin on an instance.
+// InstallPluginCommunity: install a community plugin on an instance.
 func (api *API) InstallPluginCommunity(instanceID int, pluginName string, sleep, timeout int) (
 	map[string]interface{}, error) {
 
@@ -39,25 +20,25 @@ func (api *API) InstallPluginCommunity(instanceID int, pluginName string, sleep,
 	params["plugin_name"] = pluginName
 	log.Printf("[DEBUG] go-api::plugin_community::enable path: %s", path)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 204 {
-		return nil,
-			fmt.Errorf("EnablePluginCommunity failed, status: %v, message: %v", response.StatusCode, failed)
-	}
 
-	return api.waitUntilPluginChanged(instanceID, pluginName, true, sleep, timeout)
+	switch response.StatusCode {
+	case 204:
+		return api.waitUntilPluginChanged(instanceID, pluginName, true, 1, sleep, timeout)
+	default:
+		return nil, fmt.Errorf("install community plugin failed, status: %v, message: %v",
+			response.StatusCode, failed)
+	}
 }
 
-// ReadPluginCommunity reads a specific community plugin from an instance.
+// ReadPluginCommunity: reads a specific community plugin from an instance.
 func (api *API) ReadPluginCommunity(instanceID int, pluginName string, sleep, timeout int) (
 	map[string]interface{}, error) {
 
 	log.Printf("[DEBUG] go-api::plugin_community::read instance ID: %v, name: %v", instanceID, pluginName)
 	data, err := api.ListPluginsCommunity(instanceID, sleep, timeout)
-
 	if err != nil {
 		return nil, err
 	}
@@ -72,12 +53,12 @@ func (api *API) ReadPluginCommunity(instanceID int, pluginName string, sleep, ti
 	return nil, nil
 }
 
-// ListPluginsCommunity list all community plugins for an instance.
+// ListPluginsCommunity: list all community plugins for an instance.
 func (api *API) ListPluginsCommunity(instanceID, sleep, timeout int) ([]map[string]interface{}, error) {
 	return api.listPluginsCommunityWithRetry(instanceID, 1, sleep, timeout)
 }
 
-// listPluginsCommunityWithRetry list all community plugins for an instance,
+// listPluginsCommunityWithRetry: list all community plugins for an instance,
 // with retry if the backend is busy.
 func (api *API) listPluginsCommunityWithRetry(instanceID, attempt, sleep, timeout int) (
 	[]map[string]interface{}, error) {
@@ -112,9 +93,9 @@ func (api *API) listPluginsCommunityWithRetry(instanceID, attempt, sleep, timeou
 	return data, nil
 }
 
-// UpdatePluginCommunity updates a community plugin from an instance.
-func (api *API) UpdatePluginCommunity(instanceID int, pluginName string, enabled bool, sleep, timeout int) (
-	map[string]interface{}, error) {
+// UpdatePluginCommunity: updates a community plugin from an instance.
+func (api *API) UpdatePluginCommunity(instanceID int, pluginName string, enabled bool,
+	sleep, timeout int) (map[string]interface{}, error) {
 
 	var (
 		failed map[string]interface{}
@@ -126,19 +107,20 @@ func (api *API) UpdatePluginCommunity(instanceID int, pluginName string, enabled
 	params["enabled"] = enabled
 	log.Printf("[DEBUG] go-api::plugin_community::update path: %s", path)
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 204 {
-		return nil,
-			fmt.Errorf("UpdatePluginCommunity failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return api.waitUntilPluginChanged(instanceID, pluginName, enabled, sleep, timeout)
+	switch response.StatusCode {
+	case 204:
+		return api.waitUntilPluginChanged(instanceID, pluginName, enabled, 1, sleep, timeout)
+	default:
+		return nil, fmt.Errorf("UpdatePluginCommunity failed, status: %v, message: %s",
+			response.StatusCode, failed)
+	}
 }
 
-// UninstallPluginCommunity uninstall a community plugin from an instance.
+// UninstallPluginCommunity: uninstall a community plugin from an instance.
 func (api *API) UninstallPluginCommunity(instanceID int, pluginName string, sleep, timeout int) (
 	map[string]interface{}, error) {
 
@@ -149,14 +131,38 @@ func (api *API) UninstallPluginCommunity(instanceID int, pluginName string, slee
 
 	log.Printf("[DEBUG] go-api::plugin_community::disable path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 204 {
-		return nil,
-			fmt.Errorf("DisablePluginCommunity failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return api.waitUntilPluginUninstalled(instanceID, pluginName, sleep, timeout)
+	switch response.StatusCode {
+	case 204:
+		return api.waitUntilPluginUninstalled(instanceID, pluginName, 1, sleep, timeout)
+	default:
+		return nil, fmt.Errorf("DisablePluginCommunity failed, status: %v, message: %s",
+			response.StatusCode, failed)
+	}
+}
+
+// waitUntilPluginUninstalled: wait until a community plugin been uninstalled.
+func (api *API) waitUntilPluginUninstalled(instanceID int, pluginName string,
+	attempt, sleep, timeout int) (map[string]interface{}, error) {
+
+	log.Printf("[DEBUG] go-api::plugin_community::waitUntilPluginUninstalled instance id: %v, name: %v",
+		instanceID, pluginName)
+	for {
+		time.Sleep(time.Duration(sleep) * time.Second)
+		if attempt*sleep > timeout {
+			return nil, fmt.Errorf("wait until plugin uninstalled reached timeout of %d seconds", timeout)
+		}
+
+		response, err := api.ReadPlugin(instanceID, pluginName, sleep, timeout)
+		if err != nil {
+			return nil, err
+		}
+		if len(response) == 0 {
+			return response, nil
+		}
+		attempt++
+	}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Increased reports about `Error: ReadWithRetry failed, status: 400, message: map[error:Timeout talking to backend]` when reading plugins information. Current retries (5 attempts and increased sleep) is not sufficient.

[Trello](https://trello.com/c/lzHPFjrj)

### WHAT is this pull request doing?

- Add sleep/timeout input parameters
- Update how retries works for both official and community plugins
- Clean up code

### HOW can this pull request be tested?

Run together with our CloudAMQP Terraform provider.
