### PR TITLE
Handle gone VPC resources

### DIFF
--- a/api/instance.go
+++ b/api/instance.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -10,53 +9,64 @@ import (
 )
 
 func (api *API) waitUntilReady(instanceID string) (map[string]interface{}, error) {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%s", instanceID)
+	)
+
 	log.Printf("[DEBUG] go-api::instance::waitUntilReady waiting")
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+
 	for {
 		time.Sleep(10 * time.Second)
-		response, err := api.sling.New().Path("/api/instances/").Get(instanceID).Receive(&data, &failed)
-
+		response, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
 			return nil, err
 		}
-		if response.StatusCode != 200 {
-			return nil, fmt.Errorf("waitUntilReady failed, status: %v, message: %s", response.StatusCode, failed)
-		}
-		if data["ready"] == true {
-			data["id"] = instanceID
-			return data, nil
+
+		switch response.StatusCode {
+		case 200:
+			if data["ready"] == true {
+				data["id"] = instanceID
+				return data, nil
+			}
+		default:
+			return nil, fmt.Errorf("waitUntilReady failed, status: %v, message: %s",
+				response.StatusCode, failed)
 		}
 	}
 }
 
 func (api *API) waitUntilAllNodesReady(instanceID string) error {
-	var data []map[string]interface{}
-	failed := make(map[string]interface{})
+	var (
+		data   []map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%v/nodes", instanceID)
+	)
 
 	for {
 		time.Sleep(15 * time.Second)
-		path := fmt.Sprintf("api/instances/%v/nodes", instanceID)
 		_, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
-			log.Printf("[ERROR] go-api::instance::waitUntilAllNodesReady error: %v", err)
 			return err
 		}
+
 		log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReady numberOfNodes: %v", len(data))
-		log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReady data: %v", data)
 		ready := true
 		for _, node := range data {
-			log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReady ready: %v, configured: %v", ready, node["configured"])
+			log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReady ready: %v, configured: %v",
+				ready, node["configured"])
 			ready = ready && node["configured"].(bool)
 		}
-		log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReady ready: %v", ready)
 		if ready {
 			return nil
 		}
 	}
 }
 
-func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attempt, sleep, timeout int) error {
+func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attempt, sleep,
+	timeout int) error {
+
 	var (
 		data   []map[string]interface{}
 		failed map[string]interface{}
@@ -74,7 +84,8 @@ func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attemp
 
 	ready := true
 	for _, node := range data {
-		log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured ready: %v, configured: %v", ready, node["configured"])
+		log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured ready: %v, configured: %v",
+			ready, node["configured"])
 		ready = ready && node["configured"].(bool)
 	}
 	log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured ready: %v", ready)
@@ -87,17 +98,23 @@ func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attemp
 }
 
 func (api *API) waitUntilDeletion(instanceID string) error {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%s", instanceID)
+	)
+
 	log.Printf("[DEBUG] go-api::instance::waitUntilDeletion waiting")
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
 	for {
 		time.Sleep(10 * time.Second)
-		response, err := api.sling.New().Path("/api/instances/").Get(instanceID).Receive(&data, &failed)
-
+		response, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
 			log.Printf("[DEBUG] go-api::instance::waitUntilDeletion error: %v", err)
 			return err
 		}
+
+		// TODO: Check how this works with the new API and will a change to 410 be an issue for
+		// older versions.
 		if response.StatusCode == 404 {
 			log.Print("[DEBUG] go-api::instance::waitUntilDeletion deleted")
 			return nil
@@ -106,61 +123,70 @@ func (api *API) waitUntilDeletion(instanceID string) error {
 }
 
 func (api *API) numberOfNodes(instanceID string) (int, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	path := fmt.Sprintf("api/instances/%v/nodes", instanceID)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%v/nodes", instanceID)
+	)
+
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 	log.Printf("[DEBUG] go-api::instances::numberOfNodes data: %v", data)
-
 	if err != nil {
-		fmt.Errorf("go-api::instances::numberOfNodes error: %v", err)
 		return -1, err
 	}
-	if response.StatusCode != 200 {
-		return -1, fmt.Errorf("go-api::instances::numberOfNodes failed, status: %v, message: %v", response.StatusCode, failed)
-	}
 
-	if data["nodes"] == nil {
-		log.Printf("[ERROR] go-api::instances::numberOfNodes is nil")
-		return -1, fmt.Errorf("go-api::instances::numberOfNodes is nil")
+	switch response.StatusCode {
+	case 200:
+		if data["nodes"] == nil {
+			log.Printf("[ERROR] go-api::instances::numberOfNodes is nil")
+			return -1, fmt.Errorf("go-api::instances::numberOfNodes is nil")
+		}
+		nodes, _ := strconv.Atoi(data["nodes"].(string))
+		return nodes, nil
+	default:
+		return -1, fmt.Errorf("go-api::instances::numberOfNodes failed, status: %v, message: %v",
+			response.StatusCode, failed)
 	}
-	nodes, _ := strconv.Atoi(data["nodes"].(string))
-	return nodes, nil
 }
 
 func (api *API) CreateInstance(params map[string]interface{}) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+	)
+
 	log.Printf("[DEBUG] go-api::instance::create params: %v", params)
 	response, err := api.sling.New().Post("/api/instances").BodyJSON(params).Receive(&data, &failed)
 	log.Printf("[DEBUG] go-api::instance::waitUntilReady data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("CreateInstance failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	if id, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
-		log.Printf("[DEBUG] go-api::instance::create id set: %v", data["id"])
-	} else {
-		msg := fmt.Sprintf("go-api::instance::create Invalid instance identifier: %v", data["id"])
-		log.Printf("[ERROR] %s", msg)
-		return nil, errors.New(msg)
+	switch response.StatusCode {
+	case 200:
+		if id, ok := data["id"]; ok {
+			data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
+			log.Printf("[DEBUG] go-api::instance::create id set: %v", data["id"])
+		} else {
+			return nil, fmt.Errorf("go-api::instance::create Invalid instance identifier: %v", data["id"])
+		}
+		return api.waitUntilReady(data["id"].(string))
+	default:
+		return nil, fmt.Errorf("create instance failed, status: %v, message: %s",
+			response.StatusCode, failed)
 	}
-
-	return api.waitUntilReady(data["id"].(string))
 }
 
 func (api *API) ReadInstance(instanceID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::instance::read instance ID: %v", instanceID)
-	response, err := api.sling.New().Path("/api/instances/").Get(instanceID).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::instance::read data: %v", data)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%s", instanceID)
+	)
 
+	log.Printf("[DEBUG] go-api::instance::read instance ID: %v", instanceID)
+	response, err := api.sling.New().Path(path).Receive(&data, &failed)
+	log.Printf("[DEBUG] go-api::instance::read data: %v", data)
 	if err != nil {
 		return nil, err
 	}
@@ -172,17 +198,20 @@ func (api *API) ReadInstance(instanceID string) (map[string]interface{}, error) 
 		log.Printf("[WARN] go-api::instance::read status: 410, message: The instance has been deleted")
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("ReadInstance failed, status: %v, message: %s",
+		return nil, fmt.Errorf("read instance failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}
 }
 
+// TODO: Rename to ListInstances
 func (api *API) ReadInstances() ([]map[string]interface{}, error) {
-	var data []map[string]interface{}
-	failed := make(map[string]interface{})
+	var (
+		data   []map[string]interface{}
+		failed map[string]interface{}
+	)
+
 	response, err := api.sling.New().Get("/api/instances").Receive(&data, &failed)
 	log.Printf("[DEBUG] go-api::instance::list data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
@@ -194,15 +223,18 @@ func (api *API) ReadInstances() ([]map[string]interface{}, error) {
 		log.Printf("[WARN] go-api::instance::list status: 410, message: The instance has been deleted")
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("ReadInstances failed, status: %v, message: %s",
+		return nil, fmt.Errorf("list instances failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}
 }
 
 func (api *API) UpdateInstance(instanceID string, params map[string]interface{}) error {
-	failed := make(map[string]interface{})
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%v", instanceID)
+	)
+
 	log.Printf("[DEBUG] go-api::instance::update instance ID: %v, params: %v", instanceID, params)
-	path := fmt.Sprintf("api/instances/%v", instanceID)
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -215,29 +247,32 @@ func (api *API) UpdateInstance(instanceID string, params map[string]interface{})
 		log.Printf("[WARN] go-api::instance::update status: 410, message: The instance has been deleted")
 		return nil
 	default:
-		return fmt.Errorf("UpdateInstance failed, status: %v, message: %s",
+		return fmt.Errorf("update instance failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}
 }
 
 func (api *API) DeleteInstance(instanceID string, keep_vpc bool) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::instance::delete instance ID: %v", instanceID)
-	path := fmt.Sprintf("api/instances/%s?keep_vpc=%v", instanceID, keep_vpc)
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%s?keep_vpc=%v", instanceID, keep_vpc)
+	)
 
+	log.Printf("[DEBUG] go-api::instance::delete instance ID: %v", instanceID)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
 	}
 
 	switch response.StatusCode {
 	case 204:
+		// TODO: Check how this are affected by the new API and will a change to 410 be an issue for older versions?
 		return api.waitUntilDeletion(instanceID)
 	case 410:
 		log.Printf("[WARN] go-api::instance::delete status: 410, message: The instance has been deleted")
 		return nil
 	default:
-		return fmt.Errorf("DeleteInstance failed, status: %v, message: %s",
+		return fmt.Errorf("delete instance failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}
 }

--- a/api/instance.go
+++ b/api/instance.go
@@ -113,9 +113,11 @@ func (api *API) waitUntilDeletion(instanceID string) error {
 			return err
 		}
 
-		// TODO: Check how this works with the new API and will a change to 410 be an issue for
-		// older versions.
-		if response.StatusCode == 404 {
+		switch response.StatusCode {
+		case 404:
+			log.Print("[DEBUG] go-api::instance::waitUntilDeletion deleted")
+			return nil
+		case 410:
 			log.Print("[DEBUG] go-api::instance::waitUntilDeletion deleted")
 			return nil
 		}
@@ -239,7 +241,6 @@ func (api *API) DeleteInstance(instanceID string, keep_vpc bool) error {
 
 	switch response.StatusCode {
 	case 204:
-		// TODO: Check how this are affected by the new API and will a change to 410 be an issue for older versions?
 		return api.waitUntilDeletion(instanceID)
 	case 410:
 		log.Printf("[WARN] go-api::instance::delete status: 410, message: The instance has been deleted")

--- a/api/instance.go
+++ b/api/instance.go
@@ -122,33 +122,6 @@ func (api *API) waitUntilDeletion(instanceID string) error {
 	}
 }
 
-func (api *API) numberOfNodes(instanceID string) (int, error) {
-	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
-		path   = fmt.Sprintf("api/instances/%v/nodes", instanceID)
-	)
-
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::instances::numberOfNodes data: %v", data)
-	if err != nil {
-		return -1, err
-	}
-
-	switch response.StatusCode {
-	case 200:
-		if data["nodes"] == nil {
-			log.Printf("[ERROR] go-api::instances::numberOfNodes is nil")
-			return -1, fmt.Errorf("go-api::instances::numberOfNodes is nil")
-		}
-		nodes, _ := strconv.Atoi(data["nodes"].(string))
-		return nodes, nil
-	default:
-		return -1, fmt.Errorf("go-api::instances::numberOfNodes failed, status: %v, message: %v",
-			response.StatusCode, failed)
-	}
-}
-
 func (api *API) CreateInstance(params map[string]interface{}) (map[string]interface{}, error) {
 	var (
 		data   map[string]interface{}

--- a/api/vpc.go
+++ b/api/vpc.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -9,78 +8,92 @@ import (
 )
 
 func (api *API) waitUntilVpcReady(vpcID string) error {
-	log.Printf("[DEBUG] go-api::vpc::waitUntilVpcReady waiting")
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	for {
-		path := fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
-		response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
+	)
 
+	log.Printf("[DEBUG] go-api::vpc::waitUntilVpcReady waiting")
+	for {
+		time.Sleep(10 * time.Second)
+		response, err := api.sling.New().Get(path).Receive(&data, &failed)
 		if err != nil {
 			return err
 		}
-		if response.StatusCode == 400 {
-			log.Printf("[WARN] go-api::vpc::waitUntilVpcReady status: %v, message: %s", response.StatusCode, failed)
-		} else if response.StatusCode != 200 {
-			return fmt.Errorf("waitUntilReady failed, status: %v, message: %s", response.StatusCode, failed)
-		} else if response.StatusCode == 200 {
-			return nil
-		}
 
-		time.Sleep(10 * time.Second)
+		switch response.StatusCode {
+		case 200:
+			return nil
+		case 400:
+			log.Printf("[WARN] go-api::vpc::waitUntilVpcReady status: %v, message: %s",
+				response.StatusCode, failed)
+		default:
+			return fmt.Errorf("waitUntilReady failed, status: %v, message: %s",
+				response.StatusCode, failed)
+		}
 	}
 }
 
 func (api *API) readVpcName(vpcID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	path := fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
+	)
 
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("readVpcName failed, status: %v, message: %s", response.StatusCode, failed)
+
+	switch response.StatusCode {
+	case 200:
+		return data, nil
+	default:
+		return nil, fmt.Errorf("readVpcName failed, status: %v, message: %s",
+			response.StatusCode, failed)
 	}
-	return data, nil
 }
 
 func (api *API) CreateVpcInstance(params map[string]interface{}) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc::create params: %v", params)
-	response, err := api.sling.New().Post("/api/vpcs").BodyJSON(params).Receive(&data, &failed)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = "/api/vpcs"
+	)
 
+	log.Printf("[DEBUG] go-api::vpc::create params: %v", params)
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("CreateVpcInstance failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	if id, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
-		log.Printf("[DEBUG] go-api::vpc::create id set: %v", data["id"])
-	} else {
-		msg := fmt.Sprintf("go-api::vpc::create Invalid instance identifier: %v", data["id"])
-		log.Printf("[ERROR] %s", msg)
-		return nil, errors.New(msg)
+	switch response.StatusCode {
+	case 200:
+		if id, ok := data["id"]; ok {
+			data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
+			log.Printf("[DEBUG] go-api::vpc::create id set: %v", data["id"])
+		} else {
+			return nil, fmt.Errorf("create VPC invalid instance identifier: %v", data["id"])
+		}
+		api.waitUntilVpcReady(data["id"].(string))
+		return data, nil
+	default:
+		return nil, fmt.Errorf("create VPC failed, status: %v, message: %s",
+			response.StatusCode, failed)
 	}
-
-	api.waitUntilVpcReady(data["id"].(string))
-	return data, nil
 }
 
 func (api *API) ReadVpcInstance(vpcID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/vpcs/%s", vpcID)
+	)
+
 	log.Printf("[DEBUG] go-api::vpc::read vpc ID: %s", vpcID)
-
-	path := fmt.Sprintf("/api/vpcs/%s", vpcID)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc::read data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
@@ -94,15 +107,18 @@ func (api *API) ReadVpcInstance(vpcID string) (map[string]interface{}, error) {
 		log.Printf("[WARN] go-api::vpc::read status: 410, message: The VPC has been deleted")
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("ReadVpcInstance failed, status: %v, message: %v",
+		return nil, fmt.Errorf("read VPC failed, status: %v, message: %v",
 			response.StatusCode, failed)
 	}
 }
 
 func (api *API) UpdateVpcInstance(vpcID string, params map[string]interface{}) error {
-	failed := make(map[string]interface{})
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
+	)
+
 	log.Printf("[DEBUG] go-api::instance::update vpc ID: %s, params: %v", vpcID, params)
-	path := fmt.Sprintf("api/vpcs/%s", vpcID)
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -115,17 +131,19 @@ func (api *API) UpdateVpcInstance(vpcID string, params map[string]interface{}) e
 		log.Printf("[WARN] go-api::vpc::update status: 410, message: The VPC has been deleted")
 		return nil
 	default:
-		return fmt.Errorf("UpdateInstance failed, status: %v, message: %v",
+		return fmt.Errorf("update VPC failed, status: %v, message: %v",
 			response.StatusCode, failed)
 	}
 }
 
 func (api *API) DeleteVpcInstance(vpcID string) error {
-	failed := make(map[string]interface{})
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
+	)
+
 	log.Printf("[DEBUG] go-api::vpc::delete vpc ID: %s", vpcID)
-	path := fmt.Sprintf("api/vpcs/%s", vpcID)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
-	log.Printf("[DEBUG] go-api::vpc::delete vpc ID: %s, response: %v", vpcID, response.StatusCode)
 	if err != nil {
 		return err
 	}
@@ -137,7 +155,7 @@ func (api *API) DeleteVpcInstance(vpcID string) error {
 		log.Printf("[WARN] go-api::vpc::delete status: 410, message: The VPC has been deleted")
 		return nil
 	default:
-		return fmt.Errorf("DeleteVpcInstance failed, status: %v, message: %v",
+		return fmt.Errorf("delete VPC failed, status: %v, message: %v",
 			response.StatusCode, failed)
 	}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Reported issues when trying to delete VPCs that has already been deleted when using our CloudAMQP Terraform provider. This can happen if deleting the instance without setting `keep_associated_vpc = true` and running `terraform destroy`. Extend the status code handling to respond with a warning instead of throwing an error.

Require: https://github.com/84codes/customer-console/pull/271

### WHAT is this pull request doing?

- Handle status code 410 (gone) for the VPC
- Prepare to handle status code 410 (gone) for the instance
- Clean up the code

### HOW can this pull request be tested?

Manual tested locally against our CloudAMQP Terraform provider. By destroying the instance (with `keep_associated_vpc = false`) before destroying the VPC.
