### PR TITLE
Add retry functionality to reading PrivateLink information

### DIFF
--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -33,7 +34,13 @@ func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{
 }
 
 // ReadPrivatelink: Reads PrivateLink information
-func (api *API) ReadPrivatelink(instanceID int) (map[string]interface{}, error) {
+func (api *API) ReadPrivatelink(instanceID, sleep, timeout int) (map[string]interface{}, error) {
+	return api.readPrivateLinkWithRetry(instanceID, 1, sleep, timeout)
+}
+
+func (api *API) readPrivateLinkWithRetry(instanceID, attempt, sleep, timeout int) (
+	map[string]interface{}, error) {
+
 	var (
 		data   map[string]interface{}
 		failed map[string]interface{}
@@ -43,14 +50,25 @@ func (api *API) ReadPrivatelink(instanceID int) (map[string]interface{}, error) 
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
+	} else if attempt*sleep > timeout {
+		return nil, fmt.Errorf("read PrivateLink failed, reached timeout of %d seconds", timeout)
 	}
 
-	if response.StatusCode == 200 {
+	switch response.StatusCode {
+	case 200:
 		return data, nil
-	} else {
-		return nil, fmt.Errorf("read PrivateLink failed, status: %v, message: %s",
-			response.StatusCode, failed)
+	case 400:
+		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
+			log.Printf("[INFO] go-api::privatelink::read Timeout talking to backend "+
+				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
+			attempt++
+			time.Sleep(time.Duration(sleep) * time.Second)
+			return api.readPrivateLinkWithRetry(instanceID, attempt, sleep, timeout)
+		}
 	}
+
+	return nil, fmt.Errorf("read PrivateLink failed, status: %v, message: %s",
+		response.StatusCode, failed)
 }
 
 // UpdatePrivatelink: Update allowed principals or subscriptions

--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -10,7 +10,9 @@ import (
 // EnablePrivatelink: Enable PrivateLink and wait until finished.
 // Need to enable VPC for an instance, if no standalone VPC used.
 // Wait until finished with configureable sleep and timeout.
-func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{}, sleep, timeout int) error {
+func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{},
+	sleep, timeout int) error {
+
 	var (
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
@@ -25,9 +27,10 @@ func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{
 		return err
 	}
 
-	if response.StatusCode == 204 {
+	switch response.StatusCode {
+	case 204:
 		return api.waitForEnablePrivatelinkWithRetry(instanceID, 1, sleep, timeout)
-	} else {
+	default:
 		return fmt.Errorf("enable PrivateLink failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}
@@ -83,9 +86,10 @@ func (api *API) UpdatePrivatelink(instanceID int, params map[string][]interface{
 		return err
 	}
 
-	if response.StatusCode == 204 {
+	switch response.StatusCode {
+	case 204:
 		return nil
-	} else {
+	default:
 		return fmt.Errorf("update Privatelink failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}
@@ -103,9 +107,10 @@ func (api *API) DisablePrivatelink(instanceID int) error {
 		return err
 	}
 
-	if response.StatusCode == 204 {
+	switch response.StatusCode {
+	case 204:
 		return nil
-	} else {
+	default:
 		return fmt.Errorf("disable Privatelink failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}


### PR DESCRIPTION
### WHY are these changes introduced?

Reported issues about "Timeout talking to backend" and lack of retries when reading PrivateLink information.

### WHAT is this pull request doing?

- Make retries configurable through sleep and timeout
- Add retry for read PrivateLink information
- Clean up code

### HOW can this pull request be tested?

Manual use with our CloudAMQP Terraform provider, when enable PrivateLink and read out information. 