### PR TITLE
Preparation for Go VCR testing

### DIFF
--- a/api/alarms.go
+++ b/api/alarms.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (api *API) CreateAlarm(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
+
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
 	log.Printf("[DEBUG] go-api::alarm::create instance ID: %v, params: %v", instanceID, params)

--- a/api/alarms.go
+++ b/api/alarms.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (api *API) CreateAlarm(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
-
 	data := make(map[string]interface{})
 	failed := make(map[string]interface{})
 	log.Printf("[DEBUG] go-api::alarm::create instance ID: %v, params: %v", instanceID, params)

--- a/api/api.go
+++ b/api/api.go
@@ -7,7 +7,8 @@ import (
 )
 
 type API struct {
-	sling *sling.Sling
+	sling  *sling.Sling
+	client *http.Client
 }
 
 func (api *API) DefaultRmqVersion() (map[string]interface{}, error) {
@@ -20,15 +21,16 @@ func (api *API) DefaultRmqVersion() (map[string]interface{}, error) {
 	return data, nil
 }
 
-func New(baseUrl, apiKey string, useragent string) *API {
+func New(baseUrl, apiKey string, useragent string, client *http.Client) *API {
 	if len(useragent) == 0 {
 		useragent = "84codes go-api"
 	}
 	return &API{
 		sling: sling.New().
-			Client(http.DefaultClient).
+			Client(client).
 			Base(baseUrl).
 			SetBasicAuth("", apiKey).
 			Set("User-Agent", useragent),
+		client: client,
 	}
 }

--- a/api/instance.go
+++ b/api/instance.go
@@ -18,7 +18,6 @@ func (api *API) waitUntilReady(instanceID string) (map[string]interface{}, error
 	log.Printf("[DEBUG] go-api::instance::waitUntilReady waiting")
 
 	for {
-		time.Sleep(10 * time.Second)
 		response, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
 			return nil, err
@@ -34,6 +33,7 @@ func (api *API) waitUntilReady(instanceID string) (map[string]interface{}, error
 			return nil, fmt.Errorf("waitUntilReady failed, status: %v, message: %s",
 				response.StatusCode, failed)
 		}
+		time.Sleep(10 * time.Second)
 	}
 }
 
@@ -45,7 +45,6 @@ func (api *API) waitUntilAllNodesReady(instanceID string) error {
 	)
 
 	for {
-		time.Sleep(15 * time.Second)
 		_, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
 			return err
@@ -61,6 +60,7 @@ func (api *API) waitUntilAllNodesReady(instanceID string) error {
 		if ready {
 			return nil
 		}
+		time.Sleep(15 * time.Second)
 	}
 }
 
@@ -106,7 +106,6 @@ func (api *API) waitUntilDeletion(instanceID string) error {
 
 	log.Printf("[DEBUG] go-api::instance::waitUntilDeletion waiting")
 	for {
-		time.Sleep(10 * time.Second)
 		response, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
 			log.Printf("[DEBUG] go-api::instance::waitUntilDeletion error: %v", err)
@@ -121,6 +120,7 @@ func (api *API) waitUntilDeletion(instanceID string) error {
 			log.Print("[DEBUG] go-api::instance::waitUntilDeletion deleted")
 			return nil
 		}
+		time.Sleep(10 * time.Second)
 	}
 }
 

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -23,7 +23,7 @@ func (api *API) ValidatePlan(name string) error {
 		path   = "api/plans"
 	)
 
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	response, err := api.sling.New().Client(api.client).Get(path).Receive(&data, &failed)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (api *API) ValidateRegion(region string) error {
 		platform string
 	)
 
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	response, err := api.sling.New().Client(api.client).Get(path).Receive(&data, &failed)
 	if err != nil {
 		return err
 	}

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -67,7 +67,6 @@ func (api *API) PostAction(instanceID int, nodeName string, action string) (map[
 func (api *API) waitOnNodeAction(instanceID int, nodeName string, action string) (map[string]interface{}, error) {
 	log.Printf("[DEBUG] go-api::nodes::waitOnNodeAction waiting")
 	for {
-		time.Sleep(20 * time.Second)
 		data, err := api.ReadNode(instanceID, nodeName)
 
 		if err != nil {
@@ -84,5 +83,6 @@ func (api *API) waitOnNodeAction(instanceID int, nodeName string, action string)
 				return data, nil
 			}
 		}
+		time.Sleep(20 * time.Second)
 	}
 }

--- a/api/plugins.go
+++ b/api/plugins.go
@@ -176,7 +176,6 @@ func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enable
 	attempt, sleep, timeout int) (map[string]interface{}, error) {
 
 	for {
-		time.Sleep(time.Duration(sleep) * time.Second)
 		if attempt*sleep > timeout {
 			return nil, fmt.Errorf("wait until plugin changed reached timeout of %d seconds", timeout)
 		}
@@ -193,5 +192,6 @@ func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enable
 			return response, nil
 		}
 		attempt++
+		time.Sleep(time.Duration(sleep) * time.Second)
 	}
 }

--- a/api/plugins_community.go
+++ b/api/plugins_community.go
@@ -151,7 +151,6 @@ func (api *API) waitUntilPluginUninstalled(instanceID int, pluginName string,
 	log.Printf("[DEBUG] go-api::plugin_community::waitUntilPluginUninstalled instance id: %v, name: %v",
 		instanceID, pluginName)
 	for {
-		time.Sleep(time.Duration(sleep) * time.Second)
 		if attempt*sleep > timeout {
 			return nil, fmt.Errorf("wait until plugin uninstalled reached timeout of %d seconds", timeout)
 		}
@@ -164,5 +163,6 @@ func (api *API) waitUntilPluginUninstalled(instanceID int, pluginName string,
 			return response, nil
 		}
 		attempt++
+		time.Sleep(time.Duration(sleep) * time.Second)
 	}
 }

--- a/api/upgrade_rabbitmq.go
+++ b/api/upgrade_rabbitmq.go
@@ -46,7 +46,6 @@ func (api *API) waitUntilUpgraded(instanceID int) (string, error) {
 	failed := make(map[string]interface{})
 
 	for {
-		time.Sleep(30 * time.Second)
 		path := fmt.Sprintf("api/instances/%v/nodes", instanceID)
 		_, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
@@ -65,5 +64,6 @@ func (api *API) waitUntilUpgraded(instanceID int) (string, error) {
 		if ready {
 			return "", nil
 		}
+		time.Sleep(30 * time.Second)
 	}
 }

--- a/api/vpc.go
+++ b/api/vpc.go
@@ -16,7 +16,6 @@ func (api *API) waitUntilVpcReady(vpcID string) error {
 
 	log.Printf("[DEBUG] go-api::vpc::waitUntilVpcReady waiting")
 	for {
-		time.Sleep(10 * time.Second)
 		response, err := api.sling.New().Get(path).Receive(&data, &failed)
 		if err != nil {
 			return err
@@ -32,6 +31,7 @@ func (api *API) waitUntilVpcReady(vpcID string) error {
 			return fmt.Errorf("waitUntilReady failed, status: %v, message: %s",
 				response.StatusCode, failed)
 		}
+		time.Sleep(10 * time.Second)
 	}
 }
 

--- a/api/vpc_gcp_peering.go
+++ b/api/vpc_gcp_peering.go
@@ -17,7 +17,6 @@ func (api *API) waitForGcpPeeringStatus(path, peerID string,
 	)
 
 	for {
-		time.Sleep(time.Duration(sleep) * time.Second)
 		if attempt*sleep > timeout {
 			return fmt.Errorf("wait until GCP VPC peering status reached timeout of %d seconds", timeout)
 		}
@@ -42,6 +41,7 @@ func (api *API) waitForGcpPeeringStatus(path, peerID string,
 		log.Printf("[INFO] go-api::vpc_gcp_peering::waitForGcpPeeringStatus Waiting for state = ACTIVE "+
 			"attempt %d until timeout: %d", attempt, (timeout - (attempt * sleep)))
 		attempt++
+		time.Sleep(time.Duration(sleep) * time.Second)
 	}
 }
 

--- a/api/vpc_gcp_peering.go
+++ b/api/vpc_gcp_peering.go
@@ -122,7 +122,7 @@ func (api *API) readVpcGcpPeeringWithRetry(path string, attempt, sleep, timeout 
 	if err != nil {
 		return attempt, nil, err
 	} else if attempt*sleep > timeout {
-		return attempt, nil, fmt.Errorf("read plugins reached timeout of %d seconds", timeout)
+		return attempt, nil, fmt.Errorf("read VPC peering reached timeout of %d seconds", timeout)
 	}
 
 	switch response.StatusCode {
@@ -137,7 +137,7 @@ func (api *API) readVpcGcpPeeringWithRetry(path string, attempt, sleep, timeout 
 			return api.readVpcGcpPeeringWithRetry(path, attempt, sleep, timeout)
 		}
 	}
-	return attempt, nil, fmt.Errorf("read plugin with retry failed, status: %v, message: %s",
+	return attempt, nil, fmt.Errorf("read VPC peering with retry failed, status: %v, message: %s",
 		response.StatusCode, failed)
 }
 

--- a/api/vpc_gcp_peering_withvpcid.go
+++ b/api/vpc_gcp_peering_withvpcid.go
@@ -28,7 +28,6 @@ func (api *API) RequestVpcGcpPeeringWithVpcId(vpcID string, params map[string]in
 	return data, nil
 }
 
-// func (api *API) ReadVpcGcpPeering(instanceID, sleep, timeout int) (
 func (api *API) ReadVpcGcpPeeringWithVpcId(vpcID string, sleep, timeout int) (
 	map[string]interface{}, error) {
 

--- a/main.go
+++ b/main.go
@@ -9,5 +9,5 @@ func main() {
 }
 
 func New(baseUrl, apiKey string) *api.API {
-	return api.New(baseUrl, apiKey, "84codes go-api")
+	return api.New(baseUrl, apiKey, "84codes go-api", nil)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To use Go-VCR testing package for the provider, the HTTP client transport need to be changeable.

### WHAT is this pull request doing?

- Make HTTP client accessable and to be changed.
- When polling, change to sleep after an attempt have been triggered.

### HOW can this pull request be tested?

Together with provider changes: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/257
