### PR TITLE
Add retry functionality for Webhook endpoints

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -4,66 +4,102 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
+	"time"
 )
 
 // CreateWebhook - create a webhook for a vhost and a specific qeueu
-func (api *API) CreateWebhook(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::webhook::create params: %v", params)
-	path := fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
+func (api *API) CreateWebhook(instanceID int, params map[string]interface{},
+	sleep, timeout int) (map[string]interface{}, error) {
+
+	return api.createWebhookWithRetry(instanceID, params, 1, sleep, timeout)
+}
+
+// createWebhookWithRetry: create webhook with retry if backend is busy.
+func (api *API) createWebhookWithRetry(instanceID int, params map[string]interface{},
+	attempt, sleep, timeout int) (map[string]interface{}, error) {
+
+	var (
+		data   = make(map[string]interface{})
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
+	)
+
+	log.Printf("[DEBUG] go-api::webhook#create path: %s, params: %v", path, params)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::webhook::create response data: %v", data)
+	log.Printf("[DEBUG] go-api::webhook#create response data: %v", data)
 
 	if err != nil {
 		return nil, err
-	}
-	if response.StatusCode != 201 {
-		return nil, fmt.Errorf(fmt.Sprintf("CreateWebhook failed, status: %v, message: %s", response.StatusCode, failed))
-	}
-
-	if v, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(v.(float64), 'f', 0, 64)
-	} else {
-		msg := fmt.Sprintf("go-api::webhook::create Invalid webhook identifier: %v", data["id"])
-		log.Printf("[ERROR] %s", msg)
-		return nil, fmt.Errorf(msg)
+	} else if attempt*sleep > timeout {
+		return nil, fmt.Errorf("create webhook reached timeout of %d seconds", timeout)
 	}
 
-	return data, err
+	switch response.StatusCode {
+	case 201:
+		if v, ok := data["id"]; ok {
+			data["id"] = strconv.FormatFloat(v.(float64), 'f', 0, 64)
+		} else {
+			msg := fmt.Sprintf("go-api::webhook#create Invalid webhook identifier: %v", data["id"])
+			log.Printf("[ERROR] %s", msg)
+			return nil, fmt.Errorf(msg)
+		}
+		return data, nil
+	case 400:
+		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
+			log.Printf("[INFO] go-api::webhook#read Timeout talking to backend "+
+				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
+			attempt++
+			time.Sleep(time.Duration(sleep) * time.Second)
+			return api.createWebhookWithRetry(instanceID, params, attempt, sleep, timeout)
+		}
+		return nil, fmt.Errorf("create webhook failed, status: %v, message: %s", 400, failed)
+	default:
+		return nil,
+			fmt.Errorf("create webhook with retry failed, status: %v, message: %s",
+				response.StatusCode, failed)
+	}
 }
 
 // ReadWebhook - retrieves a specific webhook for an instance
 func (api *API) ReadWebhook(instanceID int, webhookID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::webhook::read instance ID: %d, webhookID: %s", instanceID, webhookID)
-	path := fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
+	)
+
+	log.Printf("[DEBUG] go-api::webhook#read path: %s", path)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 
 	if err != nil {
 		return nil, err
 	}
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadWebhook failed, status: %v, message: %s", response.StatusCode, failed)
+		return nil, fmt.Errorf("read webhook failed, status: %v, message: %s",
+			response.StatusCode, failed)
 	}
 
 	return data, err
 }
 
-// ReadWebhooks - retrieves all webhooks for an instance.
-func (api *API) ReadWebhooks(instanceID int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::webhook::read instance ID: %d", instanceID)
-	path := fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
+// ListWebhooks - list all webhooks for an instance.
+func (api *API) ListWebhooks(instanceID int) (map[string]interface{}, error) {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
+	)
+
+	log.Printf("[DEBUG] go-api::webhook#list path: %s", path)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 
 	if err != nil {
 		return nil, err
 	}
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadWebhooks failed, status: %v, message: %s", response.StatusCode, failed)
+		return nil, fmt.Errorf("list webhooks failed, status: %v, message: %s",
+			response.StatusCode, failed)
 	}
 
 	return data, err
@@ -71,13 +107,16 @@ func (api *API) ReadWebhooks(instanceID int) (map[string]interface{}, error) {
 
 // DeleteWebhook - removes a specific webhook for an instance
 func (api *API) DeleteWebhook(instanceID int, webhookID string) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::webhook::delete instance ID: %d, webhookID: %s", instanceID, webhookID)
-	path := fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
+	)
+
+	log.Printf("[DEBUG] go-api::webhook#delete path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 
 	if response.StatusCode != 204 {
-		return fmt.Errorf("DeleteWebhook failed, status: %v, message: %s", response.StatusCode, failed)
+		return fmt.Errorf("delete webhook failed, status: %v, message: %s", response.StatusCode, failed)
 	}
 
 	return err


### PR DESCRIPTION
### WHY are these changes introduced?

Underlying handling of webhooks relies on RPC request.
Follow similar pattern as other endpoints and use retry functionality.

### WHAT is this pull request doing?

Adds retry functionality to CRUD endpoints.

### HOW can this pull request be tested?

Test together with https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/268
